### PR TITLE
Re-bind special variables in callbacks executed by request

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -131,6 +131,41 @@ control categories, archive locations, and other local variables."
 
 (defconst org-gcal-events-url "https://www.googleapis.com/calendar/v3/calendars/%s/events")
 
+(defvar org-gcal--dynamic-variables
+  (apropos-internal "^org-gcal-.*" (lambda (sym) (boundp sym)))
+  "List of dynamic variables defined by org-gcal.")
+
+(defmacro org-gcal--with-saved-state (state &rest body)
+  "Save all the dynamic variables defined by org-gcal into the STATE variable
+and then execute the BODY forms. The STATE is meant to be restored in deferred
+tasks defined inside this macro by calling ORG-GCAL--WITH-RESTORED-STATE inside
+the function definitions for those tasks. Example:
+
+(org-gcal--with-saved-state
+  state
+  (deferred:$
+    (...)
+    (deferred:nextc it
+      (lambda (req)
+        (org-gcal--with-restored-state
+          state
+          ...)))))"
+  `(let ((,state
+          (list
+           ,@(mapcar (lambda (sym) `(cons ',sym (symbol-value ',sym)))
+                     org-gcal--dynamic-variables))))
+     ,@body))
+
+(defmacro org-gcal--with-restored-state (state &rest body)
+  "Restore the dynamic variables saved in STATE by ORG-GCAL--WITH-SAVED-STATE
+while executing the BODY forms."
+  (let ((state-var (make-symbol "state")))
+    `(let* ((,state-var ,state)
+            ,@(mapcar (lambda (sym) `(,sym (cdr (assoc ',sym ,state-var))))
+                      org-gcal--dynamic-variables))
+
+       ,@body)))
+
 ;;;###autoload
 (defun org-gcal-sync (&optional a-token skip-export silent)
   "Import events from calendars.

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -246,9 +246,14 @@ SKIP-EXPORT.  Set SILENT to non-nil to inhibit notifications."
                              (with-temp-file org-gcal-token-file
                                (pp (plist-put plst
                                               (intern (concat ":" (car x)))
-                                              (mapcar (lambda (lst (cons (plist-get lst :id) (org-gcal--cons-list lst)) items)) (current-buffer))))
-                               (org-set-startup-visibility)
-                               (save-buffer)))))
+                                              (mapcar
+                                               (lambda (lst)
+                                                       (cons (plist-get lst :id)
+                                                             (org-gcal--cons-list lst)))
+                                               items))
+                                   (current-buffer)))))
+                         (org-set-startup-visibility)
+                         (save-buffer))
                        (unless silent
                          (org-gcal--notify "Completed event fetching ."
                                            (concat "Fetched data overwrote\n" (cdr x)))))))))))))

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -543,9 +543,9 @@ needed."
          (concat "Make" org-gcal-token-file))))))
 
 (defun org-gcal--get-access-token ()
-  (if org-gcal-token-plist
-      (plist-get org-gcal-token-plist :access_token)
-    (progn
+  (let ((a-token (plist-get org-gcal-token-plist :access_token)))
+    (if a-token
+        a-token
       (if (file-exists-p org-gcal-token-file)
           (progn
             (with-temp-buffer (insert-file-contents org-gcal-token-file)


### PR DESCRIPTION
In order for overriding special and custom variables in a `let` form to work
correctly, the values of the relevant variables must be re-bound inside the
callbacks executed by `request`.