### PR TITLE
use oauth2 lib and remove deferred dependency

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -136,10 +136,10 @@ Predicate functions take an event, and if they return nil the
       (org-gcal--sync cal (json-read) skip-export))))
 
 ;;;###autoload
-(defun org-gcal-sync (&optional a-token skip-export silent)
+(defun org-gcal-sync (&optional skip-export)
   "Import events from calendars.
-Using A-TOKEN and export the ones to the calendar if unless
-SKIP-EXPORT.  Set SILENT to non-nil to inhibit notifications."
+Export the ones to the calendar unless SKIP-EXPORT.  Set SILENT
+to non-nil to inhibit notifications."
   (interactive)
   ;; (org-gcal--ensure-token)
   (when org-gcal-auto-archive
@@ -179,7 +179,7 @@ SKIP-EXPORT.  Set SILENT to non-nil to inhibit notifications."
                  finally
                  (kill-buffer buf))
         (sit-for 2)
-        (org-gcal-sync nil t t)))
+        (org-gcal-sync t t)))
     (erase-buffer)
     (let ((items (org-gcal--filter (plist-get data :items ))))
 		  (if (assoc (car x) org-gcal-header-alist)
@@ -204,7 +204,7 @@ SKIP-EXPORT.  Set SILENT to non-nil to inhibit notifications."
 (defun org-gcal-fetch ()
   "Fetch event data from google calendar."
   (interactive)
-  (org-gcal-sync nil t))
+  (org-gcal-sync t))
 
 (defun org-gcal--filter (items)
   "Filter ITEMS on an AND of `org-gcal-fetch-event-filters' functions.

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -5,7 +5,7 @@
 ;; Version: 0.3
 ;; Maintainer: Raimon Grau <raimonster@gmail.com>
 ;; Copyright (C) :2014 myuhe all rights reserved.
-;; Package-Requires: ((request-deferred "0.2.0") (alert "1.1") (emacs "24") (cl-lib "0.5") (org "8.2.4"))
+;; Package-Requires: ((alert "1.1") (emacs "24") (cl-lib "0.5") (org "8.2.4"))
 ;; Keywords: convenience,
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -35,10 +35,10 @@
 
 (require 'alert)
 (require 'json)
-(require 'request-deferred)
 (require 'org-element)
 (require 'org-archive)
 (require 'cl-lib)
+(require 'oauth2)
 
 ;; Customization
 ;;; Code:
@@ -106,9 +106,6 @@ Predicate functions take an event, and if they return nil the
   :group 'org-gcal
   :type 'boolean)
 
-(defvar org-gcal-token-plist nil
-  "Token plist.")
-
 (defvar org-gcal-header-alist ())
 
 (defconst org-gcal-auth-url "https://accounts.google.com/o/oauth2/auth"
@@ -122,125 +119,86 @@ Predicate functions take an event, and if they return nil the
 
 (defconst org-gcal-events-url "https://www.googleapis.com/calendar/v3/calendars/%s/events")
 
+(defun org-gcal-auth ()
+  "Authorize."
+  (oauth2-auth-and-store org-gcal-auth-url
+                         org-gcal-token-url
+                         org-gcal-resource-url
+                         org-gcal-client-id
+                         org-gcal-client-secret
+                         "urn:ietf:wg:oauth:2.0:oob"))
+
+(defun rgc-cb (b cal skip-export)
+  (interactive)
+  (with-current-buffer b
+    ;; (search-forward "\n\n")
+    (let ((json-object-type 'plist))
+      (org-gcal--sync cal (json-read) skip-export))))
+
 ;;;###autoload
 (defun org-gcal-sync (&optional a-token skip-export silent)
   "Import events from calendars.
 Using A-TOKEN and export the ones to the calendar if unless
 SKIP-EXPORT.  Set SILENT to non-nil to inhibit notifications."
   (interactive)
-  (org-gcal--ensure-token)
+  ;; (org-gcal--ensure-token)
   (when org-gcal-auto-archive
     (dolist (i org-gcal-file-alist)
       (with-current-buffer
           (find-file-noselect (cdr i))
         (org-gcal--archive-old-event))))
-  (cl-loop for x in org-gcal-file-alist
-           do
-           (let ((x x)
-                 (a-token (if a-token
-                              a-token
-                            (org-gcal--get-access-token)))
+  (mapc (lambda (cal)
+          (let ((b (oauth2-url-retrieve-synchronously
+                    (org-gcal-auth)
+                    (format "%s?%s"
+                            (format org-gcal-events-url (first cal))
+                            (format "singleEvents=True&orderBy=startTime&timeMin=%s&timeMax=%s"
+                                    (org-gcal--subtract-time)
+                                    (org-gcal--add-time))))))
+            (rgc-cb b cal skip-export)))
+        org-gcal-file-alist))
 
-                 (skip-export skip-export)
-                 (silent silent))
-             (deferred:$
-               (request-deferred
-                (format org-gcal-events-url (car x))
-                :type "GET"
-                :params `(("access_token" . ,a-token)
-                          ("key" . ,org-gcal-client-secret)
-                          ("singleEvents" . "True")
-			                    ("orderBy" . "startTime")
-                          ("timeMin" . ,(org-gcal--subtract-time))
-                          ("timeMax" . ,(org-gcal--add-time))
-                          ("grant_type" . "authorization_code"))
-                :parser 'org-gcal--json-read
-                :error
-                (cl-function (lambda (&key error-thrown &allow-other-keys)
-                               (message "Got error: %S" error-thrown))))
-               (deferred:nextc it
-                 (lambda (response)
-                   (let
-                       ((temp (request-response-data response))
-                        (status (request-response-status-code response))
-                        (error-msg (request-response-error-thrown response)))
-                     (cond
-                      ;; If there is no network connectivity, the response will
-                      ;; not include a status code.
-                      ((eq status nil)
-                       (org-gcal--notify
-                        "Got Error"
-                        "Could not contact remote service. Please check your network connectivity."))
-                      ;; Receiving a 403 response could mean that the calendar
-                      ;; API has not been enabled. When the user goes and
-                      ;; enables it, a new token will need to be generated. This
-                      ;; takes care of that step.
-                      ((eq 401 (or (plist-get (plist-get (request-response-data response) :error) :code)
-                                   status))
-                         (org-gcal--notify
-                          "Received HTTP 401"
-                          "OAuth token expired. Now trying to refresh-token")
-                         (deferred:next
-                           (lambda()
-                             (org-gcal-refresh-token 'org-gcal-sync skip-export))))
-                      ((eq 403 status)
-                         (org-gcal--notify "Received HTTP 403"
-                                           "Ensure you enabled the Calendar API through the Developers Console, then try again.")
-                         (deferred:nextc it
-                           (lambda()
-                             (org-gcal-refresh-token 'org-gcal-sync skip-export))))
-                      ;; We got some 2xx response, but for some reason no
-                      ;; message body.
-                      ((and (> 299 status) (eq temp nil))
-                       (org-gcal--notify
-                        (concat "Received HTTP" (number-to-string status))
-                        "Error occured, but no message body."))
-                      ((not (eq error-msg nil))
-                       ;; Generic error-handler meant to provide useful
-                       ;; information about failure cases not otherwise
-                       ;; explicitly specified.
-                         (org-gcal--notify
-                          (concat "Status code: " (number-to-string status))
-                          (pp-to-string error-msg)))
-                      ;; Fetch was successful.
-                      (t
-                       (with-current-buffer (find-file-noselect (cdr x))
-                         (unless skip-export
-                           (save-excursion
-                             (cl-loop with buf = (find-file-noselect org-gcal-token-file)
-                                      for local-event in (org-gcal--parse-id (cdr x))
-                                      for pos in (org-gcal--headline-list (cdr x))
-                                      when (or
-                                            (eq (car local-event) nil)
-                                            (not (string= (cdr local-event)
-                                                          (cdr (assoc (caar local-event)
-                                                                      (with-current-buffer buf
-                                                                                        (plist-get (read (buffer-string)) (intern (concat ":" (car x))))))))))
-                                      do
-                                      (goto-char pos)
-                                      (org-gcal-post-at-point t)
-                                      finally
-                                      (kill-buffer buf))
-                           (sit-for 2)
-                           (org-gcal-sync nil t t)))
-                         (erase-buffer)
-                         (let ((items (org-gcal--filter (plist-get (request-response-data response) :items ))))
-			   (if (assoc (car x) org-gcal-header-alist)
-			       (insert (cdr (assoc (car x) org-gcal-header-alist))))
-                           (insert
-                            (mapconcat 'identity
-                                       (mapcar (lambda (lst)
-                                                 (org-gcal--cons-list lst))
-                                               items) ""))
-                           (let ((plst (with-temp-buffer (insert-file-contents org-gcal-token-file)
-                                                         (read (buffer-string)))))
-                             (with-temp-file org-gcal-token-file (pp (plist-put plst (intern (concat ":" (car x))) (mapcar (lambda (lst)
-                                                                                                                             (cons (plist-get lst :id) (org-gcal--cons-list lst)))
-                                                                                                                           items)) (current-buffer)))))
-                         (org-set-startup-visibility)
-                         (save-buffer))
-                       (unless silent
-                       (org-gcal--notify "Completed event fetching ." (concat "Fetched data overwrote\n" (cdr x)))))))))))))
+(defun org-gcal--sync (x data &optional skip-export)
+  "An X. Also data."
+  (interactive)
+  (with-current-buffer (find-file-noselect (cdr x))
+    (unless skip-export
+      (save-excursion
+        (cl-loop with buf = (find-file-noselect org-gcal-token-file)
+                 for local-event in (org-gcal--parse-id (cdr x))
+                 for pos in (org-gcal--headline-list (cdr x))
+                 when (or
+                       (eq (car local-event) nil)
+                       (not (string= (cdr local-event)
+                                     (cdr (assoc (caar local-event)
+                                                 (with-current-buffer buf
+                                                   (plist-get (read (buffer-string)) (intern (concat ":" (car x))))))))))
+                 do
+                 (goto-char pos)
+                 (org-gcal-post-at-point t)
+                 finally
+                 (kill-buffer buf))
+        (sit-for 2)
+        (org-gcal-sync nil t t)))
+    (erase-buffer)
+    (let ((items (org-gcal--filter (plist-get data :items ))))
+		  (if (assoc (car x) org-gcal-header-alist)
+			    (insert (cdr (assoc (car x) org-gcal-header-alist))))
+      (insert
+       (mapconcat 'identity
+                  (mapcar (lambda (lst)
+                            (org-gcal--cons-list lst))
+                          items) ""))
+      (let ((plst (with-temp-buffer (insert-file-contents org-gcal-token-file)
+                                    (read (buffer-string)))))
+        (with-temp-file org-gcal-token-file
+          (pp (plist-put plst
+                         (intern (concat ":" (car x)))
+                         (mapcar (lambda (lst)
+                                   (cons (plist-get lst :id) (org-gcal--cons-list lst)))
+                                 items)) (current-buffer)))))
+    (org-set-startup-visibility)
+    (save-buffer)))
 
 ;;;###autoload
 (defun org-gcal-fetch ()
@@ -291,7 +249,6 @@ filter returns NIL, discard the item."
 If SKIP-IMPORT is not nil, do not import events from the
 current calendar."
   (interactive)
-  (org-gcal--ensure-token)
   (save-excursion
     (end-of-line)
     (org-back-to-heading)
@@ -346,70 +303,6 @@ current calendar."
                  (y-or-n-p (format "Do you really want to delete event?\n\n%s\n\n" smry)))
         (org-gcal--delete-event id)))))
 
-(defun org-gcal-request-authorization ()
-  "Request OAuth authorization at AUTH-URL by launching `browse-url'.
-CLIENT-ID is the client id provided by the provider.
-It returns the code provided by the service."
-  (browse-url (concat org-gcal-auth-url
-                      "?client_id=" (url-hexify-string org-gcal-client-id)
-                      "&response_type=code"
-                      "&redirect_uri=" (url-hexify-string "urn:ietf:wg:oauth:2.0:oob")
-                      "&scope=" (url-hexify-string org-gcal-resource-url)))
-  (read-string "Enter the code your browser displayed: "))
-
-(defun org-gcal-request-token ()
-  "Refresh OAuth access at TOKEN-URL."
-  (request
-   org-gcal-token-url
-   :type "POST"
-   :data `(("client_id" . ,org-gcal-client-id)
-           ("client_secret" . ,org-gcal-client-secret)
-           ("code" . ,(org-gcal-request-authorization))
-           ("redirect_uri" .  "urn:ietf:wg:oauth:2.0:oob")
-           ("grant_type" . "authorization_code"))
-   :parser 'org-gcal--json-read
-   :success (cl-function
-             (lambda (&key data &allow-other-keys)
-               (when data
-                 (setq org-gcal-token-plist data)
-                 (org-gcal--save-sexp data org-gcal-token-file))))
-   :error
-   (cl-function (lambda (&key error-thrown &allow-other-keys)
-                (message "Got error: %S" error-thrown)))))
-
-(defun org-gcal-refresh-token (&optional fun skip-export start end smry loc desc id)
-  "Refresh OAuth access and call FUN after that.
-Pass SKIP-EXPORT, START, END, SMRY, LOC, DESC.  and ID to FUN if
-needed."
-    (deferred:$
-      (request-deferred
-       org-gcal-token-url
-       :type "POST"
-       :data `(("client_id" . ,org-gcal-client-id)
-               ("client_secret" . ,org-gcal-client-secret)
-               ("refresh_token" . ,(org-gcal--get-refresh-token))
-               ("grant_type" . "refresh_token"))
-       :parser 'org-gcal--json-read
-       :error
-       (cl-function (lambda (&key error-thrown &allow-other-keys)
-                    (message "Got error: %S" error-thrown))))
-      (deferred:nextc it
-        (lambda (response)
-          (let ((temp (request-response-data response)))
-            (plist-put org-gcal-token-plist
-                       :access_token
-                       (plist-get temp :access_token))
-            (org-gcal--save-sexp org-gcal-token-plist org-gcal-token-file)
-            org-gcal-token-plist)))
-      (deferred:nextc it
-        (lambda (token)
-          (cond ((eq fun 'org-gcal-sync)
-                 (org-gcal-sync (plist-get token :access_token) skip-export))
-                ((eq fun 'org-gcal--post-event)
-                 (org-gcal--post-event start end smry loc desc id (plist-get token :access_token)))
-                ((eq fun 'org-gcal--delete-event)
-                 (org-gcal--delete-event id (plist-get token :access_token))))))))
-
 ;; Internal
 (defun org-gcal--archive-old-event ()
   (save-excursion
@@ -435,56 +328,6 @@ needed."
                 (select-enable-clipboard nil))
             (org-archive-subtree)))))
     (save-buffer)))
-
-(defun org-gcal--save-sexp (data file)
-  (if (file-directory-p org-gcal-dir)
-      (if (file-exists-p file)
-          (if  (plist-get (read (buffer-string)) :token )
-              (with-temp-file file
-                (pp (plist-put (read (buffer-string)) :token data) (current-buffer)))
-            (with-temp-file file
-              (pp `(:token ,data :elem nil) (current-buffer))))
-        (progn
-          (find-file-noselect file)
-          (with-temp-file file
-            (pp `(:token ,data :elem nil) (current-buffer)))))
-    (progn
-      (make-directory org-gcal-dir)
-      (org-gcal--save-sexp data file))))
-
-(defun org-gcal--json-read ()
-  (let ((json-object-type 'plist))
-    (goto-char (point-min))
-    (re-search-forward "^{" nil t)
-    (delete-region (point-min) (1- (point)))
-    (goto-char (point-min))
-    (json-read-from-string
-     (decode-coding-string
-      (buffer-substring-no-properties (point-min) (point-max)) 'utf-8))))
-
-(defun org-gcal--get-refresh-token ()
-  (if org-gcal-token-plist
-      (plist-get org-gcal-token-plist :refresh_token)
-    (progn
-      (if (file-exists-p org-gcal-token-file)
-          (progn
-            (with-temp-buffer (insert-file-contents org-gcal-token-file)
-                              (plist-get (plist-get (read (buffer-string)) :token) :refresh_token)))
-        (org-gcal--notify
-         (concat org-gcal-token-file " is not exists" )
-         (concat "Make" org-gcal-token-file))))))
-
-(defun org-gcal--get-access-token ()
-  (if org-gcal-token-plist
-      (plist-get org-gcal-token-plist :access_token)
-    (progn
-      (if (file-exists-p org-gcal-token-file)
-          (progn
-            (with-temp-buffer (insert-file-contents org-gcal-token-file)
-                              (plist-get (plist-get (read (buffer-string)) :token) :access_token)))
-        (org-gcal--notify
-         (concat org-gcal-token-file " is not exists" )
-         (concat "Make " org-gcal-token-file))))))
 
 (defun org-gcal--safe-substring (string from &optional to)
   "Call the `substring' function safely.
@@ -638,12 +481,6 @@ TO.  Instead an empty string is returned."
                           (+ (if tz (car (org-gcal--time-zone seconds)) 0)
                              seconds))))))
 
-(defun org-gcal--param-date (str)
-  (if (< 11 (length str)) "dateTime" "date"))
-
-(defun org-gcal--param-date-alt (str)
-  (if (< 11 (length str)) "date" "dateTime"))
-
 (defun org-gcal--get-calendar-id-of-buffer ()
   "Find calendar id of current buffer."
   (or (cl-loop for (id . file) in org-gcal-file-alist
@@ -653,91 +490,46 @@ TO.  Instead an empty string is returned."
                           "please check/configure `org-gcal-file-alist'")
                   (buffer-name))))
 
+(defun org-gcal-start-date (time)
+    (if (< 11 (length time))
+      `("start" ("dateTime" .  ,time) ("date" .  nil))
+    `("start" ("date" .  ,time) ("dateTime" .  nil))))
+
+(defun org-gcal-end-date (time)
+  (if (< 11 (length time))
+      `("end" ("dateTime" .  nil) ("date" .  nil))
+    `("end" ("date" .  ,(org-gcal--iso-next-day time)) ("dateTime" .  nil))))
+
 (defun org-gcal--post-event (start end smry loc desc &optional id a-token skip-import skip-export)
-  (let ((stime (org-gcal--param-date start))
-        (etime (org-gcal--param-date end))
-        (stime-alt (org-gcal--param-date-alt start))
-        (etime-alt (org-gcal--param-date-alt end))
-        (a-token (if a-token
-                     a-token
-                   (org-gcal--get-access-token))))
-    (request
-     (concat
-      (format org-gcal-events-url (org-gcal--get-calendar-id-of-buffer))
-      (when id
-        (concat "/" id)))
-     :type (if id "PATCH" "POST")
-     :headers '(("Content-Type" . "application/json"))
-     :data (encode-coding-string
-            (json-encode `(("start" (,stime . ,start) (,stime-alt . nil))
-                           ("end" (,etime . ,(if (equal "date" etime)
-                                                 (org-gcal--iso-next-day end)
-                                               end)) (,etime-alt . nil))
-                           ("summary" . ,smry)
-                           ("location" . ,loc)
-                           ("description" . ,desc)))
-            'utf-8)
-     :params `(("access_token" . ,a-token)
-               ("key" . ,org-gcal-client-secret)
-               ("grant_type" . "authorization_code"))
+  (let ((method (if id "PATCH" "POST"))
+        (id (or id ""))
+        b)
+    (setq b (oauth2-url-retrieve-synchronously
+      (org-gcal-auth)
+      (concat (format org-gcal-events-url (org-gcal--get-calendar-id-of-buffer)) "/" id)
+      method
+      (encode-coding-string
+       (json-encode `(,(org-gcal-start-date start)
+                      ,(org-gcal-end-date end)
+                      ("summary" . ,smry)
+                      ("location" . ,loc)
+                      ("description" . ,desc)))
+       'utf-8)
+      '(("Content-Type" . "application/json"))))
+    (org-gcal-fetch)))
 
-     :parser 'org-gcal--json-read
-     :error (cl-function
-             (lambda (&key response &allow-other-keys)
-               (let ((status (request-response-status-code response))
-                     (error-msg (request-response-error-thrown response)))
-                 (cond
-                  ((eq status 401)
-                   (progn
-                     (org-gcal--notify
-                      "Received HTTP 401"
-                      "OAuth token expired. Now trying to refresh-token")
-                     (org-gcal-refresh-token 'org-gcal--post-event skip-export start end smry loc desc id)))
-                  (t
-                   (org-gcal--notify
-                    (concat "Status code: " (pp-to-string status))
-                    (pp-to-string error-msg)))))))
-     :success (cl-function
-               (lambda (&key data &allow-other-keys)
-                 (progn
-                   (org-gcal--notify "Event Posted"
-                                     (concat "Org-gcal post event\n  " (plist-get data :summary)))
-                     (unless skip-import (org-gcal-fetch))))))))
+(defun org-gcal--delete-event (event-id)
+  "EVENT-ID is nice."
+  (interactive)
+  (oauth2-url-retrieve-synchronously
+   (rgc-auth)
+   (format "%s/%s"
+           (format org-gcal-events-url
+                   (org-gcal--get-calendar-id-of-buffer))
+           event-id)
+   "DELETE")
+  (org-gcal-fetch))
 
-(defun org-gcal--delete-event (event-id &optional a-token)
-  (let ((a-token (if a-token
-                     a-token
-                   (org-gcal--get-access-token)))
-        (calendar-id (org-gcal--get-calendar-id-of-buffer)))
-    (request
-     (concat
-      (format org-gcal-events-url calendar-id)
-      (concat "/" event-id))
-     :type "DELETE"
-     :headers '(("Content-Type" . "application/json"))
-     :params `(("access_token" . ,a-token)
-               ("key" . ,org-gcal-client-secret)
-               ("grant_type" . "authorization_code"))
-     :error (cl-function
-             (lambda (&key response &allow-other-keys)
-               (let ((status (request-response-status-code response))
-                     (error-msg (request-response-error-thrown response)))
-                 (cond
-                  ((eq status 401)
-                   (progn
-                     (org-gcal--notify
-                      "Received HTTP 401"
-                      "OAuth token expired. Now trying to refresh-token")
-                     (org-gcal-refresh-token 'org-gcal--delete-event nil nil nil nil nil nil event-id)))
-                  (t
-                   (org-gcal--notify
-                    (concat "Status code: " (pp-to-string status))
-                    (pp-to-string error-msg)))))))
-     :success (cl-function
-               (lambda (&key &allow-other-keys)
-                 (progn
-                   (org-gcal-fetch)
-                   (org-gcal--notify "Event Deleted" "Org-gcal deleted event")))))))
 
 (defun org-gcal--capture-post ()
   (dolist (i org-gcal-file-alist)
@@ -746,17 +538,6 @@ TO.  Instead an empty string is returned."
       (org-gcal-post-at-point))))
 
 (add-hook 'org-capture-before-finalize-hook 'org-gcal--capture-post)
-
-(defun org-gcal--ensure-token ()
-  (cond
-   (org-gcal-token-plist t)
-   ((and (file-exists-p org-gcal-token-file)
-         (ignore-errors
-           (setq org-gcal-token-plist
-                 (with-temp-buffer
-                   (insert-file-contents org-gcal-token-file)
-                   (plist-get (read (current-buffer)) :token))))) t)
-   (t (org-gcal-request-token))))
 
 (defun org-gcal--timestamp-successor ()
   "Search for the next timestamp object.
@@ -788,7 +569,6 @@ beginning position."
     (plist-get plst :day)
     (plist-get plst :mon)
     (plist-get plst :year))))
-
 
 (provide 'org-gcal)
 

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -495,7 +495,7 @@ TO.  Instead an empty string is returned."
 
 (defun org-gcal-end-date (time)
   (if (< 11 (length time))
-      `("end" ("dateTime" .  nil) ("date" .  nil))
+      `("end" ("dateTime" . ,time) ("date" .  nil))
     `("end" ("date" .  ,(org-gcal--iso-next-day time)) ("dateTime" .  nil))))
 
 (defun org-gcal--post-event (start end smry loc desc &optional id)

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -178,7 +178,7 @@ to non-nil to inhibit notifications."
                  finally
                  (kill-buffer buf))
         (sit-for 2)
-        (org-gcal-sync t t)))
+        (org-gcal-sync t)))
     (erase-buffer)
     (let ((items (org-gcal--filter (plist-get data :items ))))
 		  (if (assoc (car x) org-gcal-header-alist)
@@ -243,7 +243,7 @@ filter returns NIL, discard the item."
                                   (lambda (hl) (org-element-property :end hl)))))))))))
 
 ;;;###autoload
-(defun org-gcal-post-at-point (&optional skip-import)
+(defun org-gcal-post-at-point ()
   "Post entry at point to current calendar.
 If SKIP-IMPORT is not nil, do not import events from the
 current calendar."
@@ -251,8 +251,7 @@ current calendar."
   (save-excursion
     (end-of-line)
     (org-back-to-heading)
-    (let* ((skip-import skip-import)
-           (elem (org-element-headline-parser (point-max) t))
+    (let* ((elem (org-element-headline-parser (point-max) t))
            (tobj (progn (re-search-forward "<[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]"
                                            (save-excursion (outline-next-heading) (point)))
                         (goto-char (match-beginning 0))
@@ -285,7 +284,7 @@ current calendar."
 				 (buffer-substring-no-properties
 				  (plist-get (cadr elem) :contents-begin)
 				  (plist-get (cadr elem) :contents-end))))) "")))
-      (org-gcal--post-event start end smry loc desc id nil skip-import))))
+      (org-gcal--post-event start end smry loc desc id))))
 
 ;;;###autoload
 (defun org-gcal-delete-at-point ()
@@ -499,10 +498,9 @@ TO.  Instead an empty string is returned."
       `("end" ("dateTime" .  nil) ("date" .  nil))
     `("end" ("date" .  ,(org-gcal--iso-next-day time)) ("dateTime" .  nil))))
 
-(defun org-gcal--post-event (start end smry loc desc &optional id a-token skip-import skip-export)
+(defun org-gcal--post-event (start end smry loc desc &optional id)
   (let ((method (if id "PATCH" "POST"))
-        (id (or id ""))
-        b)
+        (id (or id "")))
     (oauth2-url-retrieve
      (org-gcal-auth)
      (concat (format org-gcal-events-url (org-gcal--get-calendar-id-of-buffer)) "/" id)

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -164,18 +164,17 @@ to non-nil to inhibit notifications."
         (org-gcal--archive-old-event))))
   (let ((token (org-gcal-auth)))
     (dolist (cal org-gcal-file-alist)
-      (make-thread (lambda ()
-                     (let ((b (oauth2-url-retrieve-synchronously
-                               token
-                               (format "%s?%s"
-                                       (format org-gcal-events-url (first cal))
-                                       (format "singleEvents=True&orderBy=startTime&timeMin=%s&timeMax=%s"
-                                               (org-gcal--subtract-time)
-                                               (org-gcal--add-time)))
-                               ;; 'rgc-cb
-                               ;; (list cal skip-export)
-                               )))
-                       (rgc-cb-sync b cal skip-export)))))))
+      (let ((b (oauth2-url-retrieve-synchronously
+                token
+                (format "%s?%s"
+                        (format org-gcal-events-url (first cal))
+                        (format "singleEvents=True&orderBy=startTime&timeMin=%s&timeMax=%s"
+                                (org-gcal--subtract-time)
+                                (org-gcal--add-time)))
+                ;; 'rgc-cb
+                ;; (list cal skip-export)
+                )))
+        (rgc-cb-sync b cal skip-export)))))
 
 (defun org-gcal--sync (x data &optional skip-export)
   "An X. Also data."

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -154,8 +154,7 @@ control categories, archive locations, and other local variables."
 ;;;###autoload
 (defun org-gcal-sync (&optional skip-export)
   "Import events from calendars.
-Export the ones to the calendar unless SKIP-EXPORT.  Set SILENT
-to non-nil to inhibit notifications."
+Export the ones to the calendar unless SKIP-EXPORT."
   (interactive)
   (when org-gcal-auto-archive
     (dolist (i org-gcal-file-alist)
@@ -541,7 +540,7 @@ TO.  Instead an empty string is returned."
    '(("Content-Type" . "application/json"))))
 
 (defun org-gcal--delete-event (event-id)
-  "EVENT-ID is nice."
+  "Delete event EVENT-ID."
   (interactive)
   (oauth2-url-retrieve
    (org-gcal-auth)

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -500,7 +500,7 @@ TO.  Instead an empty string is returned."
 (defun org-gcal--get-calendar-id-of-buffer ()
   "Find calendar id of current buffer."
   (or (cl-loop for (id . file) in org-gcal-file-alist
-               if (file-equal-p file (buffer-file-name))
+               if (file-equal-p file (buffer-file-name (buffer-base-buffer)))
                return id)
       (user-error (concat "Buffer `%s' may not related to google calendar; "
                           "please check/configure `org-gcal-file-alist'")

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -162,19 +162,18 @@ to non-nil to inhibit notifications."
       (with-current-buffer
           (find-file-noselect (cdr i))
         (org-gcal--archive-old-event))))
-  (let ((token (org-gcal-auth)))
-    (dolist (cal org-gcal-file-alist)
-      (let ((b (oauth2-url-retrieve-synchronously
-                token
-                (format "%s?%s"
-                        (format org-gcal-events-url (first cal))
-                        (format "singleEvents=True&orderBy=startTime&timeMin=%s&timeMax=%s"
-                                (org-gcal--subtract-time)
-                                (org-gcal--add-time)))
-                ;; 'rgc-cb
-                ;; (list cal skip-export)
-                )))
-        (rgc-cb-sync b cal skip-export)))))
+  (dolist (cal org-gcal-file-alist)
+    (let ((b (oauth2-url-retrieve-synchronously
+              (org-gcal-auth)
+              (format "%s?%s"
+                      (format org-gcal-events-url (first cal))
+                      (format "singleEvents=True&orderBy=startTime&timeMin=%s&timeMax=%s"
+                              (org-gcal--subtract-time)
+                              (org-gcal--add-time)))
+              ;; 'rgc-cb
+              ;; (list cal skip-export)
+              )))
+      (rgc-cb-sync b cal skip-export))))
 
 (defun org-gcal--sync (x data &optional skip-export)
   "An X. Also data."

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -313,7 +313,6 @@ current calendar."
 (defun org-gcal-delete-at-point ()
   "Delete entry at point to current calendar."
   (interactive)
-  (org-gcal--ensure-token)
   (save-excursion
     (end-of-line)
     (org-back-to-heading)

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -194,7 +194,7 @@ to non-nil to inhibit notifications."
                                                    (plist-get (read (buffer-string)) (intern (concat ":" (car x))))))))))
                  do
                  (goto-char pos)
-                 (org-gcal-post-at-point t)
+                 (org-gcal-post-at-point)
                  finally
                  (kill-buffer buf))
         (sit-for 2)
@@ -308,7 +308,7 @@ current calendar."
                                                   (plist-get (cadr elem) :contents-begin)
                                                   (plist-get (cadr elem) :contents-end)))))
                    "")))
-      (org-gcal--post-event start end smry loc desc id nil skip-import))))
+      (org-gcal--post-event start end smry loc desc id))))
 
 ;;;###autoload
 (defun org-gcal-delete-at-point ()
@@ -547,7 +547,7 @@ TO.  Instead an empty string is returned."
   "EVENT-ID is nice."
   (interactive)
   (oauth2-url-retrieve
-   (rgc-auth)
+   (org-gcal-auth)
    (format "%s/%s"
            (format org-gcal-events-url
                    (org-gcal--get-calendar-id-of-buffer))

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -5,7 +5,7 @@
 ;; Version: 0.3
 ;; Maintainer: Raimon Grau <raimonster@gmail.com>
 ;; Copyright (C) :2014 myuhe all rights reserved.
-;; Package-Requires: ((alert "1.1") (emacs "24") (cl-lib "0.5") (org "8.2.4"))
+;; Package-Requires: ((alert "1.1") (oauth2 "0.11") (emacs "24") (cl-lib "0.5") (org "8.2.4"))
 ;; Keywords: convenience,
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -157,25 +157,25 @@ control categories, archive locations, and other local variables."
 Export the ones to the calendar unless SKIP-EXPORT.  Set SILENT
 to non-nil to inhibit notifications."
   (interactive)
-  ;; (org-gcal--ensure-token)
   (when org-gcal-auto-archive
     (dolist (i org-gcal-file-alist)
       (with-current-buffer
           (find-file-noselect (cdr i))
         (org-gcal--archive-old-event))))
-  (dolist (cal org-gcal-file-alist)
-    (make-thread (lambda ()
-                   (let ((b (oauth2-url-retrieve-synchronously
-                             (org-gcal-auth)
-                             (format "%s?%s"
-                                     (format org-gcal-events-url (first cal))
-                                     (format "singleEvents=True&orderBy=startTime&timeMin=%s&timeMax=%s"
-                                             (org-gcal--subtract-time)
-                                             (org-gcal--add-time)))
-                             ;; 'rgc-cb
-                             ;; (list cal skip-export)
-                             )))
-                     (rgc-cb-sync b cal skip-export))))))
+  (let ((token (org-gcal-auth)))
+    (dolist (cal org-gcal-file-alist)
+      (make-thread (lambda ()
+                     (let ((b (oauth2-url-retrieve-synchronously
+                               token
+                               (format "%s?%s"
+                                       (format org-gcal-events-url (first cal))
+                                       (format "singleEvents=True&orderBy=startTime&timeMin=%s&timeMax=%s"
+                                               (org-gcal--subtract-time)
+                                               (org-gcal--add-time)))
+                               ;; 'rgc-cb
+                               ;; (list cal skip-export)
+                               )))
+                       (rgc-cb-sync b cal skip-export)))))))
 
 (defun org-gcal--sync (x data &optional skip-export)
   "An X. Also data."

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -501,20 +501,25 @@ TO.  Instead an empty string is returned."
 (defun org-gcal--post-event (start end smry loc desc &optional id)
   (let ((method (if id "PATCH" "POST"))
         (id (or id "")))
-    (oauth2-url-retrieve
-     (org-gcal-auth)
-     (concat (format org-gcal-events-url (org-gcal--get-calendar-id-of-buffer)) "/" id)
-     (lambda (status) (org-gcal-fetch))
-     nil
-     method
-     (encode-coding-string
-      (json-encode `(,(org-gcal-start-date start)
-                     ,(org-gcal-end-date end)
-                     ("summary" . ,smry)
-                     ("location" . ,loc)
-                     ("description" . ,desc)))
-      'utf-8)
-     '(("Content-Type" . "application/json")))))
+    (org-gcal--post-event-internal
+     start end smry loc desc method
+     (concat (format org-gcal-events-url (org-gcal--get-calendar-id-of-buffer)) "/" id))))
+
+(defun org-gcal--post-event-internal (start end smry loc desc method url)
+  (oauth2-url-retrieve
+   (org-gcal-auth)
+   url
+   (lambda (status) (org-gcal-fetch))
+   nil
+   method
+   (encode-coding-string
+    (json-encode `(,(org-gcal-start-date start)
+                   ,(org-gcal-end-date end)
+                   ("summary" . ,smry)
+                   ("location" . ,loc)
+                   ("description" . ,desc)))
+    'utf-8)
+   '(("Content-Type" . "application/json"))))
 
 (defun org-gcal--delete-event (event-id)
   "EVENT-ID is nice."


### PR DESCRIPTION
Use oauth2 library instead of manual managing of tokens. http calls
are done through it so we don't use deferred.el anymore.