### PR TITLE
Makes org-gcal work with indirect buffers

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -665,7 +665,7 @@ TO.  Instead an empty string is returned."
 (defun org-gcal--get-calendar-id-of-buffer ()
   "Find calendar id of current buffer."
   (or (cl-loop for (id . file) in org-gcal-file-alist
-               if (file-equal-p file (buffer-file-name))
+               if (file-equal-p file (buffer-file-name (buffer-base-buffer)))
                return id)
       (user-error (concat "Buffer `%s' may not related to google calendar; "
                           "please check/configure `org-gcal-file-alist'")


### PR DESCRIPTION
This makes the code work with indirect buffers as well as normal buffers. 
Working with indirect buffers make org-gcal-post-at-point work with capture buffers, and make the capture hook work.