### PR TITLE
 Fix issue where multi-line locations led to duplicate calendar entries

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -616,6 +616,7 @@ TO.  Instead an empty string is returned."
                            :date))
          (start (if stime stime sday))
          (end   (if etime etime eday)))
+    (when loc (replace-regexp-in-string "\n" ", " loc))
     (concat
      "* " smry "\n"
      "  :PROPERTIES:\n"


### PR DESCRIPTION
Multi-line locations broke the org property drawer, leading to events not being identified correctly as already present (thus creating duplicates). In this PR I substituted newlines for ", " to remedy this issue.