### PR TITLE
Fixed regexp that led to double property drawers and timestamps

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -314,7 +314,7 @@
                       (replace-regexp-in-string
                        "\\`\\(?: *<[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].*?>$\\)\n?\n?" ""
                        (replace-regexp-in-string
-                        " *:PROPERTIES:\n  \\(.*\\(?:\n.*\\)*?\\) :END:\n\n" ""
+                        " *:PROPERTIES:\n *\\(.*\\(?:\n.*\\)*?\\) *:END:\n+" ""
                         (buffer-substring-no-properties
                          (plist-get (cadr elem) :contents-begin)
                          (plist-get (cadr elem) :contents-end)))) "")))


### PR DESCRIPTION
This is a port of https://github.com/myuhe/org-gcal.el/pull/122 to this repository.