### PR TITLE
Add hangouts link if present.

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -605,6 +605,7 @@ TO.  Instead an empty string is returned."
          (desc  (plist-get plst :description))
          (loc   (plist-get plst :location))
          (link  (plist-get plst :htmlLink))
+         (meet  (plist-get plst :hangoutLink))
          (id    (plist-get plst :id))
          (stime (plist-get (plist-get plst :start)
                            :dateTime))
@@ -622,6 +623,11 @@ TO.  Instead an empty string is returned."
      "  :PROPERTIES:\n"
      (when loc "  :LOCATION: ") loc (when loc "\n")
      "  :LINK: ""[[" link "][Go to gcal web page]]\n"
+     (when meet
+       (format "  %s [[%s][%s]]\n"
+               ":HANGOUTS:"
+               meet
+               "Join Hangouts Meet"))
      "  :ID: " id "\n"
      "  :END:\n"
      (if (or (string= start end) (org-gcal--alldayp start end))


### PR DESCRIPTION
**Use of case**
As a calendar user, I often have hangout video-conferences bound to my calendar meetings. As follows:
![image](https://user-images.githubusercontent.com/1654802/55330262-e1184a00-5490-11e9-8301-ccedcdb1ab01.png)

So it is really useful for this use case to be able to join a meeting without having to open the calendar. Especially if you have several gmail accounts on the browser, since upon opening the calendar link, it opens always the default calendar. Meaning that in most cases the user has to manually switch calendars to click on the hangouts link.

This PR parses the hangouts link and shows it if present, as follows:
![image](https://user-images.githubusercontent.com/1654802/55330610-ba0e4800-5491-11e9-97d9-f20008f4362f.png)

Then, by positioning the cursor on it and pressing C-c C-o it just opens on the browser. Simplifying this task a lot.

**Related discussions**
We have discussed about this in this issue #31.