### PR TITLE
org-gcal-delete-at-point: remove :org-gcal: drawer after deleting event

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -591,7 +591,22 @@ If SKIP-EXPORT is not nil, don’t overwrite the event on the server."
                       (org-element-property :ID elem))))
       (when (and event-id
                  (y-or-n-p (format "Do you really want to delete event?\n\n%s\n\n" smry)))
-        (org-gcal--delete-event calendar-id event-id etag marker)))))
+        (deferred:$
+          (org-gcal--delete-event calendar-id event-id etag (copy-marker marker))
+          ;; Delete :org-gcal: drawer after deleting event. This will preserve
+          ;; the ID for links, but will ensure functions in this module don’t
+          ;; identify the entry as a Calendar event.
+          (deferred:nextc it
+            (lambda (_)
+              (org-with-point-at marker
+                (set-marker marker nil)
+                (when (re-search-forward
+                       (format
+                        "^[ \t]*:%s:[^z-a]*?\n[ \t]*:END:[ \t]*\n?"
+                        (regexp-quote org-gcal-drawer-name))
+                       (save-excursion (outline-next-heading) (point))
+                       'noerror)
+                  (replace-match "" 'fixedcase))))))))))
 
 (defun org-gcal-request-authorization ()
   "Request OAuth authorization at AUTH-URL by launching `browse-url'.
@@ -1195,7 +1210,8 @@ Returns a ‘deferred’ object that can be used to wait for completion."
                           (goto-char (marker-position marker))
                           (org-gcal--update-entry
                            calendar-id
-                           (request-response-data response))))))))
+                           (request-response-data response))))
+                      (deferred:succeed nil)))))
                ;; Generic error-handler meant to provide useful information about
                ;; failure cases not otherwise explicitly specified.
                ((not (eq error-msg nil))
@@ -1205,7 +1221,8 @@ Returns a ‘deferred’ object that can be used to wait for completion."
                 (error "Got error %S: %S" status-code error-msg))
                ;; Fetch was successful.
                (t
-                (org-gcal--notify "Event Deleted" "Org-gcal deleted event")))))))
+                (org-gcal--notify "Event Deleted" "Org-gcal deleted event")
+                (deferred:succeed nil)))))))
       :finally
       (lambda ()
         (set-marker marker nil)))))


### PR DESCRIPTION
This prevents org-gcal-sync-buffer from considering the entry as a Calendar
event after deleting it.

Depends on #42 