### PR TITLE
Fix some bugs in handling of ID properties:

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -452,7 +452,9 @@ canonical ID, so that existing links won’t be broken."
       ;; it as the first ID in the entry.
       (org-entry-delete (point) "ID")
       (org-entry-put (point) "ID" entry-id)
-      (org-id-add-location entry-id (buffer-file-name (buffer-base-buffer)))
+      (let ((bfn (buffer-file-name (buffer-base-buffer))))
+        (when bfn
+          (org-id-add-location entry-id bfn)))
       ;; Now find the ID just inserted and insert the other IDs in their
       ;; original order.
       (let* ((range (org-get-property-block)))


### PR DESCRIPTION
- Only use an existing ID if it matches the format of the IDs created by
  org-gcal.
- Use `org-entry-get` and related functions instead of `org-element-property`
  as much as feasible. `org-element-property` doesn't always read the first ID
  in an entry, which is the behavior we want.
- Remove `org-gcal--property-from-name` because it's now unused.
- Only update org-id location when buffer file name not nil