### PR TITLE
org-gcal-sync: enable incremental sync of events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ before_install:
   - cask
   - cask install
 env:
-  - EVM_EMACS=emacs-26.1-travis-linux-xenial
-  - EVM_EMACS=emacs-26.2-travis-linux-xenial
   - EVM_EMACS=emacs-26.3-travis-linux-xenial
   - EVM_EMACS=emacs-git-snapshot-travis-linux-xenial
 matrix:

--- a/Cask
+++ b/Cask
@@ -1,4 +1,5 @@
 (source melpa)
+(source gnu)
 
 (package-file "org-gcal.el")
 


### PR DESCRIPTION
This means that, after the first fetch of events, only events that have changed
will be retrieved by future calls to `org-gcal-sync` or `org-gcal-fetch`. To
save the sync tokens, org-gcal has taken a dependency on the
[`persist`](https://elpa.gnu.org/packages/persist.html) library.

With this sync, events on the first fetch will no longer necessarily be
retrieved in chronological order, because the `"orderBy"` parameter to the
Calendar API disables incremental sync. If this is important, you should
probably call `M-x org-sort` in your calendar event files yourself.

Fixes #77 