### PR TITLE
Fetch instances of recurring events

### DIFF
--- a/README.org
+++ b/README.org
@@ -214,6 +214,45 @@ delete the corresponding Org mode headlines:
 
 Modify =org-gcal-notify-p= from =t= to =nil=
 
+** Collect instances of recurring events under parent event
+
+By default, =org-gcal-recurring-events-mode= is set to ='top-level=, which means
+that new fetched events that are instances of recurring events will be inserted
+at the top level of the file for the calendar ID configured in
+=org-gcal-fetch-file-alist=:
+
+#+BEGIN_SRC org
+  ,* Meeting
+  SCHEDULED: <2020-08-07 Fri 11:00>
+  ,* Meeting
+  SCHEDULED: <2020-08-14 Fri 11:00>
+  ,* Meeting
+  SCHEDULED: <2020-08-21 Fri 11:00>
+  ,* Meeting
+  SCHEDULED: <2020-08-28 Fri 11:00>
+#+END_SRC
+
+If =org-gcal-recurring-events-mode= is instead set to ='nested=, such events
+will be inserted as Org-mode child headlines under the headline for the parent
+event:
+
+#+BEGIN_SRC org
+  ,* Meeting
+  SCHEDULED: <2017-02-17 Fri 11:00>
+  ,** Meeting
+  SCHEDULED: <2020-08-07 Fri 11:00>
+  ,** Meeting
+  SCHEDULED: <2020-08-14 Fri 11:00>
+  ,** Meeting
+  SCHEDULED: <2020-08-21 Fri 11:00>
+  ,** Meeting
+  SCHEDULED: <2020-08-28 Fri 11:00>
+#+END_SRC
+
+Here the parent meeting has been running for several years, but only the
+instances of the meeting in the range given by =org-gcal-down-days= and
+=org-gcal-up-days= are fetched.
+
 * Errors
 ** Duplicate ID
 


### PR DESCRIPTION
Before, we fetched individual instances of recurring events as single events, and didn't fetch the parent recurring events at all. However, it's nice to have the parent event present to keep in sync with an Org-mode habit. In addition, filing all the instances of recurring events under the parent event helps to keep gcal.org cleaner, making it much more usable.

Therefore, I've added an option `org-gcal-recurring-events-mode`. By default, the treatment of recurring events is the same as before - that is, they are inserted individually at the top level. However, if `org-gcal-recurring-events-mode` is set to `'nested`, we instead insert instances of recurring events under the parent event headline. See the updated README.org for more details.