### PR TITLE
Fix org-gcal--capture-post hook

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -1728,12 +1728,17 @@ Returns a ‘deferred’ object that can be used to wait for completion."
         (set-marker marker nil)))))
 
 (defun org-gcal--capture-post ()
-  (dolist (i org-gcal-fetch-file-alist)
-    (when (string=  (file-name-nondirectory (cdr i))
-                    (substring (buffer-name) 8))
-      (org-gcal-post-at-point))))
+    (when (not org-note-abort)
+      (save-excursion
+        (save-window-excursion
+          (let ((inhibit-message t))
+            (org-capture-goto-last-stored))
+          (dolist (i org-gcal-fetch-file-alist)
+            (when (string= (file-name-nondirectory (cdr i))
+                           (buffer-name))
+              (org-gcal-post-at-point)))))))
 
-(add-hook 'org-capture-before-finalize-hook 'org-gcal--capture-post)
+(add-hook 'org-capture-after-finalize-hook 'org-gcal--capture-post)
 
 (defun org-gcal--ensure-token ()
   "Ensure that access, refresh, and sync token variables in expected state."


### PR DESCRIPTION
This fixes #62, and most likely #68 and #99 as well. Namely, `org-gcal--capture-post` as a hook before org-capture finalization resulted in deferred errors and duplicate events (when used in conjunction with a `org-gcal-sync` hook). We change it to run after finalization which fixes these issues.