### PR TITLE
Remove unused imports from org-generic-id

### DIFF
--- a/org-generic-id.el
+++ b/org-generic-id.el
@@ -17,8 +17,6 @@
 ;;; Code:
 
 (require 'org)
-(require 'org-refile)
-(require 'ol)
 
 (declare-function message-make-fqdn "message" ())
 (declare-function org-goto-location "org-goto" (&optional _buf help))


### PR DESCRIPTION
These imports were left over from `org-id`, but because `org-generic-id` has a reduced scope, it doesn't need these imports.

Fixes #130 