### PR TITLE
org-gcal-post-at-point: work even if ETag is absent

### DIFF
--- a/Cask
+++ b/Cask
@@ -4,6 +4,5 @@
 (package-file "org-gcal.el")
 
 (development
-  (depends-on "ert")
   (depends-on "el-mock")
   (depends-on "ert-runner"))

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -959,7 +959,8 @@ This will also update the stored ID locations using
            (skip-export skip-export)
            (marker (point-marker))
            (elem (org-element-headline-parser (point-max) t))
-           (smry (org-get-heading 'no-tags 'no-todo 'no-priority 'no-comment))
+           (smry (substring-no-properties
+                  (org-get-heading 'no-tags 'no-todo 'no-priority 'no-comment)))
            (loc (org-entry-get (point) "LOCATION"))
            (recurrence (org-entry-get (point) "recurrence"))
            (event-id (org-gcal--get-id (point)))

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -1583,7 +1583,7 @@ Returns a ‘deferred’ object that can be used to wait for completion."
         (request-deferred
          (concat
           (org-gcal-events-url calendar-id)
-          (when (and event-id etag)
+          (when event-id
             (concat "/" event-id)))
          :type (if event-id "PATCH" "POST")
          :headers (append


### PR DESCRIPTION
When the event ID was stored in the `ID` property, I decided to use
`ETag` as a backup to get greater assurance that the `ID` property that
might have already been stored in the event was known to GCal (and would
not 404). However, since commit 135cbe1
the event ID is stored in its own property, so the mere presence of an
`event-id` property means that the event is almost certainly known to
GCal.

This change makes the code more robust in case `ETag` is missing for
some reason, and makes generating headlines from `calendar-id` and
`event-id` which will then be populated by `org-gcal-post-at-point`
easier - it's no longer necessary to remember to add an `ETag` property,
which would be immediately overwritten anyway.