### PR TITLE
Fix #172, point to beginning for parsing headline

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -1428,26 +1428,30 @@ For valid values of EXISTING-MODE see
   (save-excursion
     (goto-char (point-min))
     (while (re-search-forward org-heading-regexp nil t)
-      (condition-case nil
-          (goto-char (cdr (org-gcal--timestamp-successor)))
-        (error (error "Org-gcal error: Couldn't parse %s"
-                      (buffer-file-name))))
-      (let ((elem (org-element-headline-parser (point-max) t))
-            (tobj (cadr (org-element-timestamp-parser))))
-        (when (>
-               (time-to-seconds (time-subtract (current-time) (days-to-time org-gcal-up-days)))
-               (time-to-seconds (encode-time 0  (if (plist-get tobj :minute-end)
-                                                    (plist-get tobj :minute-end) 0)
-                                             (if (plist-get tobj :hour-end)
-                                                 (plist-get tobj :hour-end) 24)
-                                             (plist-get tobj :day-end)
-                                             (plist-get tobj :month-end)
-                                             (plist-get tobj :year-end))))
-          (org-gcal--notify "Archived event." (org-element-property :title elem))
-          (let ((kill-ring kill-ring)
-                (select-enable-clipboard nil))
-            (org-archive-subtree)))))
-    (save-buffer)))
+      ; Go to beginning of line to parse the headline
+      (beginning-of-line)
+      (let ((elem (org-element-headline-parser (point-max) t)))
+
+        ; Go to next timestamp to parse it
+        (condition-case nil
+            (goto-char (cdr (org-gcal--timestamp-successor)))
+          (error (error "Org-gcal error: Couldn't parse %s"
+                        (buffer-file-name))))
+        (let ((tobj (cadr (org-element-timestamp-parser))))
+          (when (>
+                 (time-to-seconds (time-subtract (current-time) (days-to-time org-gcal-up-days)))
+                 (time-to-seconds (encode-time 0 (if (plist-get tobj :minute-end)
+                                                      (plist-get tobj :minute-end) 0)
+                                               (if (plist-get tobj :hour-end)
+                                                   (plist-get tobj :hour-end) 24)
+                                               (plist-get tobj :day-end)
+                                               (plist-get tobj :month-end)
+                                               (plist-get tobj :year-end))))
+            (org-gcal--notify "Archived event." (org-element-property :title elem))
+            (let ((kill-ring kill-ring)
+                  (select-enable-clipboard nil))
+              (org-archive-subtree))))))
+      (save-buffer)))
 
 (defun org-gcal--save-sexp (data file)
   "Print Lisp object DATA to FILE, creating it if necessary."

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -1428,30 +1428,36 @@ For valid values of EXISTING-MODE see
   (save-excursion
     (goto-char (point-min))
     (while (re-search-forward org-heading-regexp nil t)
-      ; Go to beginning of line to parse the headline
-      (beginning-of-line)
-      (let ((elem (org-element-headline-parser (point-max) t)))
+      (let ((properties (org-entry-properties)))
+        ; Check if headline is managed by `org-gcal', and hasn't been archived
+        ; yet. Only in that case, potentially archive.
+        (when (and (assoc "ORG-GCAL-MANAGED" properties)
+                     (not (assoc "ARCHIVE_TIME" properties)))
 
-        ; Go to next timestamp to parse it
-        (condition-case nil
-            (goto-char (cdr (org-gcal--timestamp-successor)))
-          (error (error "Org-gcal error: Couldn't parse %s"
-                        (buffer-file-name))))
-        (let ((tobj (cadr (org-element-timestamp-parser))))
-          (when (>
-                 (time-to-seconds (time-subtract (current-time) (days-to-time org-gcal-up-days)))
-                 (time-to-seconds (encode-time 0 (if (plist-get tobj :minute-end)
-                                                      (plist-get tobj :minute-end) 0)
-                                               (if (plist-get tobj :hour-end)
-                                                   (plist-get tobj :hour-end) 24)
-                                               (plist-get tobj :day-end)
-                                               (plist-get tobj :month-end)
-                                               (plist-get tobj :year-end))))
-            (org-gcal--notify "Archived event." (org-element-property :title elem))
-            (let ((kill-ring kill-ring)
-                  (select-enable-clipboard nil))
-              (org-archive-subtree))))))
-      (save-buffer)))
+          ; Go to beginning of line to parse the headline
+          (beginning-of-line)
+          (let ((elem (org-element-headline-parser (point-max) t)))
+
+            ; Go to next timestamp to parse it
+            (condition-case nil
+                (goto-char (cdr (org-gcal--timestamp-successor)))
+              (error (error "Org-gcal error: Couldn't parse %s"
+                            (buffer-file-name))))
+            (let ((tobj (cadr (org-element-timestamp-parser))))
+              (when (>
+                     (time-to-seconds (time-subtract (current-time) (days-to-time org-gcal-up-days)))
+                     (time-to-seconds (encode-time 0 (if (plist-get tobj :minute-end)
+                                                         (plist-get tobj :minute-end) 0)
+                                                   (if (plist-get tobj :hour-end)
+                                                       (plist-get tobj :hour-end) 24)
+                                                   (plist-get tobj :day-end)
+                                                   (plist-get tobj :month-end)
+                                                   (plist-get tobj :year-end))))
+                (org-gcal--notify "Archived event." (org-element-property :title elem))
+                (let ((kill-ring kill-ring)
+                      (select-enable-clipboard nil))
+                  (org-archive-subtree))))))))
+    (save-buffer)))
 
 (defun org-gcal--save-sexp (data file)
   "Print Lisp object DATA to FILE, creating it if necessary."

--- a/test/org-gcal-test.el
+++ b/test/org-gcal-test.el
@@ -1,7 +1,7 @@
 ;;; org-gcal-test.el --- Tests for org-gcal.el -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2019 Robert Irelan
-;; Package-Requires: ((org-gcal) (el-mock))
+;; Package-Requires: ((org-gcal) (el-mock) (emacs "24.3"))
 
 ;; Author: Robert Irelan <rirelan@gmail.com>
 
@@ -29,6 +29,9 @@
 (require 'org-gcal)
 (require 'cl-lib)
 (require 'el-mock)
+(let* ((org-el-source (file-truename (locate-library "org.el")))
+       (org-root-dir (f-dirname (f-dirname org-el-source))))
+  (require 'org-test (concat org-root-dir "/testing/org-test.el")))
 
 (defconst org-gcal-test-calendar-id "foo@foobar.com")
 


### PR DESCRIPTION
To parse an org headline, the point needs to be at the beginning of it.
After that, we move to the timestamp to parse it too.

Fixes #172 