### PR TITLE
Support syncing the "link" Org property with Google Calendar

### DIFF
--- a/README.org
+++ b/README.org
@@ -25,6 +25,8 @@ screen that says "This app isn't verified". You will need to click on the
 
 * Requirements
 
+- Emacs 26+
+- [[https://orgmode.org/][Org mode]] 9.3+
 - [[https://github.com/tkf/emacs-request][tkf/emacs-request]]
 - [[https://github.com/jwiegley/alert][jwiegley/alert]]
 - [[https://elpa.gnu.org/packages/persist.html][~persist~]]

--- a/test/org-gcal-test.el
+++ b/test/org-gcal-test.el
@@ -1,7 +1,7 @@
 ;;; org-gcal-test.el --- Tests for org-gcal.el -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2019 Robert Irelan
-;; Package-Requires: ((org-gcal) (el-mock))
+;; Package-Requires: ((org-gcal) (el-mock) (emacs "26"))
 
 ;; Author: Robert Irelan <rirelan@gmail.com>
 
@@ -63,6 +63,10 @@
  },
  \"reminders\": {
   \"useDefault\": true
+ },
+ \"source\": {
+  \"url\": \"https://google.com\",
+  \"title\": \"Google\"
  }
 }
 ")
@@ -75,10 +79,10 @@
   (replace-regexp-in-string
    "\"dateTime\": \"2019-10-06T17:00:00-07:00\""
    "\"date\": \"2019-10-06\""
-  (replace-regexp-in-string
-   "\"dateTime\": \"2019-10-06T21:00:00-07:00\""
-   "\"date\": \"2019-10-07\""
-                            org-gcal-test-event-json)))
+   (replace-regexp-in-string
+    "\"dateTime\": \"2019-10-06T21:00:00-07:00\""
+    "\"date\": \"2019-10-07\""
+                             org-gcal-test-event-json)))
 
 (defmacro org-gcal-test--with-temp-buffer (contents &rest body)
   "Create a ‘org-mode’ enabled temp buffer with CONTENTS.
@@ -140,6 +144,8 @@ object."
                     "\"12344321\""))
      (should (equal (org-element-property :LOCATION elem)
                     "Foobar's desk"))
+     (should (equal (org-element-property :LINK elem)
+              "[[https://google.com][Google]]"))
      (should (equal (org-element-property :TRANSPARENCY elem)
                     "opaque"))
      (should (equal (org-element-property :CALENDAR-ID elem)
@@ -171,6 +177,7 @@ object."
 :PROPERTIES:
 :ETag:     \"9999\"
 :LOCATION: Somewhere else
+:link: [[https://yahoo.com][Yahoo!]]
 :TRANSPARENCY: transparent
 :calendar-id: foo@foobar.com
 :entry-id:       foobar1234/foo@foobar.com
@@ -191,6 +198,8 @@ Old event description
                     "\"12344321\""))
      (should (equal (org-element-property :LOCATION elem)
                     "Foobar's desk"))
+     (should (equal (org-element-property :LINK elem)
+              "[[https://google.com][Google]]"))
      (should (equal (org-element-property :TRANSPARENCY elem)
                     "opaque"))
      (should (equal (org-element-property :CALENDAR-ID elem)
@@ -225,6 +234,7 @@ Second paragraph
 :PROPERTIES:
 :ETag:     \"9999\"
 :LOCATION: Somewhere else
+:link: [[https://yahoo.com][Yahoo!]]
 :calendar-id: foo@foobar.com
 :entry-id:       foobar1234/foo@foobar.com
 :END:
@@ -249,6 +259,8 @@ Old event description
                         "\"12344321\""))
          (should (equal (org-element-property :LOCATION elem)
                         "Foobar's desk"))
+         (should (equal (org-element-property :LINK elem)
+                        "[[https://google.com][Google]]"))
          (should (equal (org-element-property :CALENDAR-ID elem)
                         "foo@foobar.com"))
          (should (equal (org-element-property :ENTRY-ID elem)
@@ -283,6 +295,8 @@ Second paragraph
                         "\"12344321\""))
          (should (equal (org-element-property :LOCATION elem)
                         "Foobar's desk"))
+         (should (equal (org-element-property :LINK elem)
+                        "[[https://google.com][Google]]"))
          (should (equal (org-element-property :TRANSPARENCY elem)
                         "opaque"))
          (should (equal (org-element-property :CALENDAR-ID elem)
@@ -326,6 +340,7 @@ Second paragraph
 :PROPERTIES:
 :ETag:     \"9999\"
 :LOCATION: Somewhere else
+:link: [[https://yahoo.com][Yahoo!]]
 :TRANSPARENCY: transparent
 :calendar-id: foo@foobar.com
 :entry-id:       foobar1234/foo@foobar.com
@@ -352,6 +367,8 @@ Old event description
                         "\"12344321\""))
          (should (equal (org-element-property :LOCATION elem)
                         "Foobar's desk"))
+         (should (equal (org-element-property :LINK elem)
+                        "[[https://google.com][Google]]"))
          (should (equal (org-element-property :TRANSPARENCY elem)
                         "opaque"))
          (should (equal (org-element-property :CALENDAR-ID elem)
@@ -390,6 +407,8 @@ Second paragraph
                         "\"12344321\""))
          (should (equal (org-element-property :LOCATION elem)
                         "Foobar's desk"))
+         (should (equal (org-element-property :LINK elem)
+                        "[[https://google.com][Google]]"))
          (should (equal (org-element-property :TRANSPARENCY elem)
                         "opaque"))
          (should (equal (org-element-property :CALENDAR-ID elem)
@@ -432,6 +451,7 @@ SCHEDULED: <9999-10-06 Sun 17:00-21:00>
 :PROPERTIES:
 :ETag:     \"9999\"
 :LOCATION: Somewhere else
+:link: [[https://yahoo.com][Yahoo!]]
 :TRANSPARENCY: transparent
 :calendar-id: foo@foobar.com
 :entry-id:       foobar1234/foo@foobar.com
@@ -454,6 +474,8 @@ Old event description
                      "\"12344321\""))
       (should (equal (org-element-property :LOCATION elem)
                      "Foobar's desk"))
+      (should (equal (org-element-property :LINK elem)
+                     "[[https://google.com][Google]]"))
       (should (equal (org-element-property :TRANSPARENCY elem)
                      "opaque"))
       (should (equal (org-element-property :CALENDAR-ID elem)
@@ -481,6 +503,7 @@ Second paragraph
 * Old event summary
 :PROPERTIES:
 :LOCATION: Somewhere else
+:link: [[https://yahoo.com][Yahoo!]]
 :TRANSPARENCY: transparent
 :calendar-id: foo@foobar.com
 :entry-id:       ABCD-EFGH
@@ -501,6 +524,8 @@ Old event description
                      "\"12344321\""))
       (should (equal (org-element-property :LOCATION elem)
                      "Foobar's desk"))
+      (should (equal (org-element-property :LINK elem)
+                     "[[https://google.com][Google]]"))
       (should (equal (org-element-property :TRANSPARENCY elem)
                      "opaque"))
       (should (equal (org-element-property :CALENDAR-ID elem)
@@ -534,6 +559,7 @@ Second paragraph
 :PROPERTIES:
 :ETag:     \"12344321\"
 :LOCATION: Foobar's desk
+:link: [[https://google.com][Google]]
 :TRANSPARENCY: opaque
 :calendar-id: foo@foobar.com
 :entry-id:       foobar1234/foo@foobar.com
@@ -551,7 +577,8 @@ Second paragraph
     (stub org-generic-id-add-location => nil)
     (stub org-gcal-request-token => (deferred:succeed nil))
     (mock (org-gcal--post-event "2019-10-06T17:00:00Z" "2019-10-06T21:00:00Z"
-                                "My event summary" "Foobar's desk" 
+                                "My event summary" "Foobar's desk"
+                                `((url . "https://google.com") (title . "Google"))
                                 "My event description\n\nSecond paragraph"
                                 "foo@foobar.com"
                                 * "opaque" "\"12344321\"" "foobar1234"
@@ -568,6 +595,7 @@ returned from the Google Calendar API."
 :PROPERTIES:
 :ETag:     \"12344321\"
 :LOCATION: Original location
+:link: [[https://yahoo.com][Yahoo!]]
 :TRANSPARENCY: transparent
 :calendar-id: foo@foobar.com
 :entry-id:       foobar1234/foo@foobar.com
@@ -607,6 +635,8 @@ Original second paragraph
                            "\"12344321\""))
             (should (equal (org-element-property :LOCATION elem)
                            "Foobar's desk"))
+            (should (equal (org-element-property :LINK elem)
+                           "[[https://google.com][Google]]"))
             (should (equal (org-element-property :TRANSPARENCY elem)
                            "opaque"))
             (should (equal (org-element-property :CALENDAR-ID elem)
@@ -638,6 +668,7 @@ set to \"gcal\"."
 :PROPERTIES:
 :ETag:     \"12344321\"
 :LOCATION: Foobar's desk
+:link: [[https://google.com][Google]]
 :TRANSPARENCY: opaque
 :calendar-id: foo@foobar.com
 :entry-id:       foobar1234/foo@foobar.com
@@ -657,6 +688,7 @@ Second paragraph
       (mock (y-or-n-p *) => nil)
       (mock (org-gcal--post-event "2019-10-06T17:00:00Z" "2019-10-06T21:00:00Z"
                                   "My event summary" "Foobar's desk"
+                                  `((url . "https://google.com") (title . "Google"))
                                   "My event description\n\nSecond paragraph"
                                   "foo@foobar.com"
                                   * "opaque" "\"12344321\"" "foobar1234"
@@ -673,6 +705,7 @@ set to \"org\"."
 :PROPERTIES:
 :ETag:     \"12344321\"
 :LOCATION: Foobar's desk
+:link: [[https://google.com][Google]]
 :TRANSPARENCY: opaque
 :calendar-id: foo@foobar.com
 :entry-id:       foobar1234/foo@foobar.com
@@ -691,6 +724,7 @@ Second paragraph
       (stub org-gcal-request-token => (deferred:succeed nil))
       (mock (org-gcal--post-event "2019-10-06T17:00:00Z" "2019-10-06T21:00:00Z"
                                   "My event summary" "Foobar's desk"
+                                  `((url . "https://google.com") (title . "Google"))
                                   "My event description\n\nSecond paragraph"
                                   "foo@foobar.com"
                                   * "opaque" "\"12344321\"" "foobar1234"
@@ -725,6 +759,7 @@ Second paragraph
       (mock (y-or-n-p *) => nil)
       (mock (org-gcal--post-event "2019-10-06T17:00:00Z" "2019-10-06T21:00:00Z"
                                   "My event summary" "Foobar's desk"
+                                  nil
                                   "My event description\n\nSecond paragraph"
                                   "foo@foobar.com"
                                   * "opaque" "\"12344321\"" nil
@@ -742,6 +777,7 @@ set to \"org\"."
 :PROPERTIES:
 :ETag:     \"12344321\"
 :LOCATION: Foobar's desk
+:link: [[https://google.com][Google]]
 :TRANSPARENCY: opaque
 :calendar-id: foo@foobar.com
 :END:
@@ -759,6 +795,7 @@ Second paragraph
       (stub org-gcal-request-token => (deferred:succeed nil))
       (mock (org-gcal--post-event "2019-10-06T17:00:00Z" "2019-10-06T21:00:00Z"
                                   "My event summary" "Foobar's desk"
+                                  `((url . "https://google.com") (title . "Google"))
                                   "My event description\n\nSecond paragraph"
                                   "foo@foobar.com"
                                   * "opaque" "\"12344321\"" nil
@@ -776,6 +813,7 @@ Second paragraph
 :PROPERTIES:
 :ETag:     \"12344321\"
 :LOCATION: Foobar's desk
+:link: [[https://google.com][Google]]
 :TRANSPARENCY: opaque
 :calendar-id: foo@foobar.com
 :ID:       foobar1234/foo@foobar.com
@@ -794,6 +832,7 @@ Second paragraph
     (stub org-gcal-request-token => (deferred:succeed nil))
     (mock (org-gcal--post-event "2019-10-06T17:00:00Z" "2019-10-06T21:00:00Z"
                                 "My event summary" "Foobar's desk"
+                                `((url . "https://google.com") (title . "Google"))
                                 "My event description\n\nSecond paragraph"
                                 "foo@foobar.com"
                                 * "opaque" "\"12344321\"" "foobar1234"
@@ -806,6 +845,7 @@ Second paragraph
 :PROPERTIES:
 :ETag:     \"12344321\"
 :LOCATION: Foobar's desk
+:link: [[https://google.com][Google]]
 :TRANSPARENCY: opaque
 :calendar-id: foo@foobar.com
 :ID:             hello-world
@@ -825,6 +865,7 @@ Second paragraph
     (stub org-gcal-request-token => (deferred:succeed nil))
     (mock (org-gcal--post-event "2019-10-06T17:00:00Z" "2019-10-06T21:00:00Z"
                                 "My event summary" "Foobar's desk"
+                                `((url . "https://google.com") (title . "Google"))
                                 "My event description\n\nSecond paragraph"
                                 "foo@foobar.com"
                                 * "opaque" "\"12344321\"" "foobar1234"
@@ -841,6 +882,7 @@ an org-gcal Calendar Event ID can't be retrieved from the current entry."
 * My event summary
 :PROPERTIES:
 :LOCATION: Foobar's desk
+:link: [[https://google.com][Google]]
 :TRANSPARENCY: opaque
 :calendar-id: foo@foobar.com
 :END:
@@ -858,6 +900,7 @@ Second paragraph
       (stub org-gcal-request-token => (deferred:succeed nil))
       (mock (org-gcal--post-event "2019-10-06T17:00:00Z" "2019-10-06T21:00:00Z"
                                   "My event summary" "Foobar's desk"
+                                  `((url . "https://google.com") (title . "Google"))
                                   "My event description\n\nSecond paragraph"
                                   "foo@foobar.com"
                                   * "opaque" nil nil
@@ -868,6 +911,7 @@ Second paragraph
 * My event summary
 :PROPERTIES:
 :LOCATION: Foobar's desk
+:link: [[https://google.com][Google]]
 :TRANSPARENCY: opaque
 :calendar-id: foo@foobar.com
 :entry-id: ABCD-EFGH
@@ -886,6 +930,7 @@ Second paragraph
       (stub org-gcal-request-token => (deferred:succeed nil))
       (mock (org-gcal--post-event "2019-10-06T17:00:00Z" "2019-10-06T21:00:00Z"
                                   "My event summary" "Foobar's desk"
+                                  `((url . "https://google.com") (title . "Google"))
                                   "My event description\n\nSecond paragraph"
                                   "foo@foobar.com"
                                   * "opaque" nil nil
@@ -908,7 +953,7 @@ org-gcal properties with sane default values."
     (stub org-gcal-request-token => (deferred:succeed nil))
     (mock (org-gcal--post-event "2019-10-06T17:00:00+0000" "2019-10-06T21:00:00+0000"
                                 "My event summary" nil
-                                nil
+                                nil nil
                                 "foo@foobar.com"
                                 * "opaque" nil nil
                                 * * *))
@@ -934,7 +979,7 @@ CLOCK: [2019-06-06 Thu 17:00]--[2019-06-06 Thu 18:00] => 1:00
           (lambda (_p initial-contents) initial-contents)))
       (mock (org-gcal--post-event "2019-10-06T17:00:00+0000" "2019-10-06T18:00:00+0000"
                                   "My event summary" nil
-                                  nil
+                                  nil nil
                                   "foo@foobar.com"
                                   * "opaque" nil nil
                                   * * *))
@@ -978,6 +1023,7 @@ SCHEDULED: <2019-10-06 Sun 17:00>--<2019-10-07 Mon 21:00>
 :PROPERTIES:
 :ETag:     \"12344321\"
 :LOCATION: Foobar's desk
+:link: [[https://google.com][Google]]
 :TRANSPARENCY: opaque
 :calendar-id: foo@foobar.com
 :entry-id:       foobar1234/foo@foobar.com
@@ -994,6 +1040,7 @@ Second paragraph
     (stub org-gcal-request-token => (deferred:succeed nil))
     (mock (org-gcal--post-event "2019-10-06T17:00:00Z" "2019-10-07T21:00:00Z"
                                 "My event summary" "Foobar's desk"
+                                `((url . "https://google.com") (title . "Google"))
                                 "My event description\n\nSecond paragraph"
                                 "foo@foobar.com"
                                 * "opaque" "\"12344321\"" "foobar1234"
@@ -1013,6 +1060,7 @@ SCHEDULED: <2019-10-06 Sun 17:00>--<2019-10-07 Mon 21:00>
 :PROPERTIES:
 :ETag:     \"12344321\"
 :LOCATION: Foobar's desk
+:link: [[https://google.com][Google]]
 :TRANSPARENCY: opaque
 :calendar-id: foo@foobar.com
 :entry-id:       foobar1234/foo@foobar.com
@@ -1082,17 +1130,17 @@ Second paragraph
 (ert-deftest org-gcal-test--save-with-full-day-event ()
   "Verify that a full day event will get set correctly."
    (org-gcal-test--with-temp-buffer
-   "* "
-   (org-gcal--update-entry org-gcal-test-calendar-id
-                           org-gcal-test-full-day-event)
-   (org-back-to-heading)
+    "* "
+    (org-gcal--update-entry org-gcal-test-calendar-id
+                            org-gcal-test-full-day-event)
+    (org-back-to-heading)
    ;; Check contents of "org-gcal" drawer
-   (re-search-forward ":org-gcal:")
-   (let ((elem (org-element-at-point)))
-     (should (equal (buffer-substring-no-properties
-                     (org-element-property :contents-begin elem)
-                     (org-element-property :contents-end elem))
-                    "\
+    (re-search-forward ":org-gcal:")
+    (let ((elem (org-element-at-point)))
+      (should (equal (buffer-substring-no-properties
+                      (org-element-property :contents-begin elem)
+                      (org-element-property :contents-end elem))
+                     "\
 <2019-10-06 Sun>
 
 My event description
@@ -1105,17 +1153,17 @@ Second paragraph
   (let (
         (org-gcal-local-timezone "Europe/London"))
    (org-gcal-test--with-temp-buffer
-   "* "
-   (org-gcal--update-entry org-gcal-test-calendar-id
-                           org-gcal-test-full-day-event)
-   (org-back-to-heading)
+    "* "
+    (org-gcal--update-entry org-gcal-test-calendar-id
+                            org-gcal-test-full-day-event)
+    (org-back-to-heading)
    ;; Check contents of "org-gcal" drawer
-   (re-search-forward ":org-gcal:")
-   (let ((elem (org-element-at-point)))
-     (should (equal (buffer-substring-no-properties
-                     (org-element-property :contents-begin elem)
-                     (org-element-property :contents-end elem))
-                    "\
+    (re-search-forward ":org-gcal:")
+    (let ((elem (org-element-at-point)))
+      (should (equal (buffer-substring-no-properties
+                      (org-element-property :contents-begin elem)
+                      (org-element-property :contents-end elem))
+                     "\
 <2019-10-06 Sun>
 
 My event description
@@ -1150,7 +1198,7 @@ Second paragraph
            "2021-03-03T19:30:00+0000"))
   (should (equal
            (org-gcal--convert-time-to-local-timezone "2021-03-03T11:30:00-08:00" "Europe/London")
-           "2021-03-03T19:30:00+0000"))
+           "2021-03-03T19:30:00+0000")))
   ;; FIXME: Passed in local with Emacs 26.3 and 27.1, Failed in GitHub CI
   ;; (should (equal
   ;;          (org-gcal--convert-time-to-local-timezone "2021-03-03T11:30:00-08:00" "Europe/Oslo")
@@ -1164,7 +1212,7 @@ Second paragraph
   ;; (should (equal
   ;;          (org-gcal--convert-time-to-local-timezone "2021-03-03T11:30:00-08:00" "Asia/Shanghai")
   ;;          "2021-03-04T03:30:00+0800"))
-  )
+
 
 
 ;;; TODO: Figure out mocking for POST/PATCH followed by GET


### PR DESCRIPTION
The "link" property on events will be synced with the "source"
[property in Google Calendar](https://developers.google.com/calendar/api/v3/reference/events#source).

Also clarify in README that the minimum requirements for Org-gcal.el are
now Emacs 26 and Org 9.3.