### PR TITLE
Add calendar file associated with calendar ID to prompt

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -1248,8 +1248,15 @@ For valid values of EXISTING-MODE see
       ;; Fill in Calendar ID if not already present.
       (unless calendar-id
         (setq calendar-id
-              (completing-read "Calendar ID: "
-                               (mapcar #'car org-gcal-file-alist)))
+              ;; Completes read with prompts like "CALENDAR-FILE (CALENDAR-ID)",
+              ;; and then uses ‘replace-regexp-in-string’ to extract just
+              ;; CALENDAR-ID.
+              (replace-regexp-in-string
+               ".*(\\(.*?\\))$" "\\1"
+               (completing-read "Calendar ID: "
+                                (mapcar
+                                 (lambda (x) (format "%s (%s)" (cdr x) (car x)))
+                                 org-gcal-fetch-file-alist))))
         (org-entry-put (point) org-gcal-calendar-id-property calendar-id))
       (when (equal managed "gcal")
         (unless existing-mode


### PR DESCRIPTION
When using org-gcal-post-at-point and choosing one of the calendars you
have set in org-gcal-fetch-file-alist, you can get a list where it's
recognize some of your own calendars. Something like:

```
...
snatolhcagoesntibqvwmkjsanto@group.calendar.google.com
...
```

To address this, change the `completing-read` to show the file
associated with each calendar ID in `org-gcal-fetch-file-alist`.

Fix #178