### PR TITLE
Fixes to links

### DIFF
--- a/test/org-gcal-test.el
+++ b/test/org-gcal-test.el
@@ -101,6 +101,16 @@ always located at the beginning of the buffer."
     (insert json)
     (org-gcal--json-read)))
 
+(defun org-gcal-test--title-to-string (elem)
+  "Get :title from ELEM and convert to string."
+  (let ((prop (org-element-property :title elem)))
+    (cond
+     ((listp prop) (car prop))
+     ((stringp prop) prop)
+     (t
+      (user-error "org-gcal-test--title-to-string: unhandled type for :title prop of elem %S"
+                  elem)))))
+
 (defconst org-gcal-test-event
   (org-gcal-test--json-read-string org-gcal-test-event-json))
 
@@ -118,7 +128,7 @@ always located at the beginning of the buffer."
          ""
          (let ((data '(:foo :bar)))
            (org-gcal--save-sexp data file)
-           (should (equal (buffer-string)
+           (should (string-equal (buffer-string)
                           ""))
            (should (equal (org-gcal--read-file-contents file)
                           `(:token ,data :elem nil)))
@@ -138,7 +148,7 @@ object."
                            org-gcal-test-event)
    (org-back-to-heading)
    (let ((elem (org-element-at-point)))
-     (should (equal (org-element-property :title elem)
+     (should (equal (org-gcal-test--title-to-string elem)
                     "My event summary"))
      (should (equal (org-element-property :ETAG elem)
                     "\"12344321\""))
@@ -192,7 +202,7 @@ Old event description
                            org-gcal-test-event)
    (org-back-to-heading)
    (let ((elem (org-element-at-point)))
-     (should (equal (org-element-property :title elem)
+     (should (equal (org-gcal-test--title-to-string elem)
                     "My event summary"))
      (should (equal (org-element-property :ETAG elem)
                     "\"12344321\""))
@@ -251,7 +261,7 @@ Old event description
                                org-gcal-test-cancelled-event)
        (org-back-to-heading)
        (let ((elem (org-element-at-point)))
-         (should (equal (org-element-property :title elem)
+         (should (equal (org-gcal-test--title-to-string elem)
                         "My event summary"))
          (should (equal (org-element-property :todo-keyword elem)
                         "CANCELLED"))
@@ -287,7 +297,7 @@ Second paragraph
                                org-gcal-test-cancelled-event)
        (org-back-to-heading)
        (let ((elem (org-element-at-point)))
-         (should (equal (org-element-property :title elem)
+         (should (equal (org-gcal-test--title-to-string elem)
                         "My event summary"))
          (should (equal (org-element-property :todo-keyword elem)
                         nil))
@@ -359,7 +369,7 @@ Old event description
                                org-gcal-test-cancelled-event)
        (org-back-to-heading)
        (let ((elem (org-element-at-point)))
-         (should (equal (org-element-property :title elem)
+         (should (equal (org-gcal-test--title-to-string elem)
                         "My event summary"))
          (should (equal (org-element-property :todo-keyword elem)
                         "CANCELLED"))
@@ -399,7 +409,7 @@ Second paragraph
                                org-gcal-test-cancelled-event)
        (org-back-to-heading)
        (let ((elem (org-element-at-point)))
-         (should (equal (org-element-property :title elem)
+         (should (equal (org-gcal-test--title-to-string elem)
                         "My event summary"))
          (should (equal (org-element-property :todo-keyword elem)
                         "CANCELLED"))
@@ -468,7 +478,7 @@ Old event description
                       :raw-value
                       (org-element-property :scheduled elem))
                      "<2019-10-06 Sun 17:00-21:00>"))
-      (should (equal (org-element-property :title elem)
+      (should (equal (org-gcal-test--title-to-string elem)
                      "My event summary"))
       (should (equal (org-element-property :ETAG elem)
                      "\"12344321\""))
@@ -518,7 +528,7 @@ Old event description
                             org-gcal-test-event)
     (org-back-to-heading)
     (let ((elem (org-element-at-point)))
-      (should (equal (org-element-property :title elem)
+      (should (equal (org-gcal-test--title-to-string elem)
                      "My event summary"))
       (should (equal (org-element-property :ETAG elem)
                      "\"12344321\""))
@@ -629,7 +639,7 @@ Original second paragraph
           (org-back-to-heading)
           (should (equal update-entry-hook-called t))
           (let ((elem (org-element-at-point)))
-            (should (equal (org-element-property :title elem)
+            (should (equal (org-gcal-test--title-to-string elem)
                            "My event summary"))
             (should (equal (org-element-property :ETAG elem)
                            "\"12344321\""))


### PR DESCRIPTION
- Support bare URL (no org-link syntax, or URL without description)
- Support `ROAM_REFS` as an alternative to `link` for org-roam files,
  but only when round tripping is possible.