### PR TITLE
Fix cancel

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -1726,7 +1726,12 @@ heading."
     (when loc (replace-regexp-in-string "\n" ", " loc))
     (org-edit-headline
      (cond
+      ;; Don’t update headline if the new summary is the same as the CANCELLED
+      ;; todo keyword.
+      ((equal smry org-gcal-cancelled-todo-keyword) (org-gcal--headline))
       (smry smry)
+      ;; Set headline to “busy” if there is no existing headline and no summary
+      ;; from server.
       ((or (null (org-gcal--headline))
            (string-empty-p (org-gcal--headline)))
        "busy")

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -150,8 +150,8 @@ The events will always be marked cancelled before they’re removed if
           (const :tag "Always remove without prompting" t)))
 
 (defcustom org-gcal-remove-events-with-cancelled-todo nil
-  "Whether to attempt to remove Org-mode headlines for events marked with \
-‘org-gcal-cancelled-todo-keyword’.
+  "Whether to attempt to remove Org-mode headlines for cancelled events.
+Specifically effects events marked with ‘org-gcal-cancelled-todo-keyword’.
 
 By default, this is set to nil so that if you decline removing an event when
 ‘org-gcal-remove-api-cancelled-events’ is set to ‘ask’, you won’t be prompted
@@ -314,8 +314,8 @@ See: https://developers.google.com/calendar/v3/reference/events/insert."
           (url-hexify-string calendar-id)))
 
 (defun org-gcal-instances-url (calendar-id event-id)
-  "URL used to request access to instances of recurring event EVENT-ID on \
-calendar CALENDAR-ID."
+  "URL used to request access to instances of recurring events.
+Returns a URL for recurrent event EVENT-ID on calendar CALENDAR-ID."
   (format "https://www.googleapis.com/calendar/v3/calendars/%s/events/%s/instances"
           (url-hexify-string calendar-id)
           (url-hexify-string event-id)))
@@ -1119,8 +1119,8 @@ This will also update the stored ID locations using
 (defun org-gcal--get-time-and-desc ()
   "Get the timestamp and description of the event at point.
 
-  Return a plist with :start, :end, and :desc keys. The value for a key is nil if
-  not present."
+  Return a plist with :start, :end, and :desc keys. The value for a key is nil
+  if not present."
   (let (start end desc tobj elem)
     (save-excursion
       (org-gcal--back-to-heading)
@@ -1605,8 +1605,8 @@ delete calendar info from events on calendars you no longer have access to."
         :sec  (string-to-number (org-gcal--safe-substring str 17 19))))
 
 (defun org-gcal--parse-calendar-time (time)
-  "Parse TIME, the start or end time object from a Calendar API Events \
-  resource, into an Emacs time object."
+  "Parse TIME, the start or end time object from Calendar API Events resource.
+Return an Emacs time object from ‘encode-time'."
   (org-gcal--parse-calendar-time-string
    (or (plist-get time :dateTime)
        (plist-get time :date))))

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -1699,8 +1699,7 @@ arguments as passed to this function and the point moved to the beginning of the
 heading."
   (unless (org-at-heading-p)
     (user-error "Must be on Org-mode heading."))
-  (let* ((smry  (or (plist-get event :summary)
-                    "busy"))
+  (let* ((smry  (plist-get event :summary))
          (desc  (plist-get event :description))
          (loc   (plist-get event :location))
          (source (plist-get event :source))
@@ -1725,7 +1724,13 @@ heading."
          (recurrence (plist-get event :recurrence))
          (elem))
     (when loc (replace-regexp-in-string "\n" ", " loc))
-    (org-edit-headline smry)
+    (org-edit-headline
+     (cond
+      (smry smry)
+      ((or (null (org-gcal--headline))
+           (string-empty-p (org-gcal--headline)))
+       "busy")
+      (t (org-gcal--headline))))
     (org-entry-put (point) org-gcal-etag-property etag)
     (when recurrence (org-entry-put (point) "recurrence" (format "%s" recurrence)))
     (when loc (org-entry-put (point) "LOCATION" loc))

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -988,6 +988,11 @@ Calendar. For SILENT and FILTER-DATE see ‘org-gcal-sync-buffer’."
      deferred:debug-on-signal t)
     (message "org-gcal-debug ENABLED"))))
 
+(defun org-gcal--headline ()
+  "Get bare headline at current point."
+  (substring-no-properties
+   (org-get-heading 'no-tags 'no-todo 'no-priority 'no-comment)))
+
 (defun org-gcal--filter (items)
   "Filter ITEMS on an AND of `org-gcal-fetch-event-filters' functions.
 Run each element from ITEMS through all of the filters.  If any
@@ -1227,8 +1232,7 @@ For valid values of EXISTING-MODE see
            (skip-export skip-export)
            (marker (point-marker))
            (elem (org-element-headline-parser (point-max) t))
-           (smry (substring-no-properties
-                  (org-get-heading 'no-tags 'no-todo 'no-priority 'no-comment)))
+           (smry (org-gcal--headline))
            (loc (org-entry-get (point) "LOCATION"))
            (source
             (when-let ((link-string
@@ -1335,7 +1339,7 @@ delete calendar info from events on calendars you no longer have access to."
     (end-of-line)
     (org-gcal--back-to-heading)
     (let* ((marker (point-marker))
-           (smry (org-get-heading 'no-tags 'no-todo 'no-priority 'no-comment))
+           (smry (org-gcal--headline))
            (event-id (org-gcal--get-id (point)))
            (etag (org-entry-get (point) org-gcal-etag-property))
            (calendar-id
@@ -1843,7 +1847,7 @@ heading."
 
 Depends on the value of ‘org-gcal-remove-api-cancelled-events’."
   (when-let (((and org-gcal-remove-api-cancelled-events))
-             (smry (org-get-heading 'no-tags 'no-todo 'no-priority 'no-comment))
+             (smry (org-gcal--headline))
              ((or (eq org-gcal-remove-api-cancelled-events t)
                   (y-or-n-p (format "Delete Org headline for cancelled event\n%s? "
                                     (or smry ""))))))


### PR DESCRIPTION
Don't update existing headlines to say "busy" when an event is cancelled. This is caused by the cancelled event missing a title.