### PR TITLE
org-generic-id-update-id-locations: don't scan unmodified files

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -387,14 +387,15 @@ SKIP-EXPORT.  Set SILENT to non-nil to inhibit notifications."
         (deferred:nextc it
           (lambda (_)
             (org-generic-id-update-id-locations org-gcal-entry-id-property)
-            (mapc
-             (lambda (file)
-               (with-current-buffer (find-file-noselect file 'nowarn)
-                 (org-with-wide-buffer
-                  (org-gcal--sync-unlock)
-                  (org-gcal-sync-buffer skip-export silent 'filter-time
-                                        'filter-managed))))
-             org-generic-id-files))))
+            (when t
+              (mapc
+               (lambda (file)
+                 (with-current-buffer (find-file-noselect file 'nowarn)
+                   (org-with-wide-buffer
+                    (org-gcal--sync-unlock)
+                    (org-gcal-sync-buffer skip-export silent 'filter-time
+                                          'filter-managed))))
+               (org-generic-id-files))))))
       :finally
       (lambda ()
         (org-gcal--sync-unlock)))))

--- a/test/org-generic-id-test.el
+++ b/test/org-generic-id-test.el
@@ -35,55 +35,66 @@
           ;; resolve the symlink manually at the start.
           (file-truename (make-temp-file "my.org.")))
          (org-agenda-files (list org-file))
-         (org-generic-id-extra-files nil)
-         (org-generic-id-locations-alist
-          `(("ID"
-             (,org-file "id1"))
-            ("SN"
-             (,org-file "sn1"))))
-         (org-generic-id-locations
-          (org-generic-id--locations-alist-to-hash
-           org-generic-id-locations-alist)))
+         (org-generic-id-extra-files nil))
     ;; Reset various variables by saving and reloading.
     (org-generic-id-locations-save)
     (org-generic-id-locations-load)
-    (with-temp-file org-file
-      (org-mode)
-      (insert "\
+    ;; We run the test in a temp buffer because ‘org-generic-id-find’ will by
+    ;; default search for the ID in the current buffer if it’s not found in
+    ;; ‘org-generic-id-locations’.  We want to exercise the ID search/update, so
+    ;; we don’t want to fall back to the current buffer.  We thus need to switch
+    ;; buffer to ‘org-file’ to update it.
+    (with-temp-buffer
+      (with-current-buffer (find-file-noselect org-file)
+        (org-mode)
+        (insert "\
 * id1
 :PROPERTIES:
 :ID: id1
 :SN: sn1
-:END:
-
+:END:"))
+      (org-generic-id-update-id-locations "ID")
+      (org-generic-id-update-id-locations "SN")
+      ;; Round trip variables
+      (org-generic-id-locations-save)
+      (org-generic-id-locations-load)
+      (let (m)
+        (setq m (org-generic-id-find-id-in-file
+                 "ID" "id1" org-file))
+        (should (equal m
+                       `(,org-file . 1)))
+        (setq m (org-generic-id-find "ID" "id1"))
+        (should (equal m
+                       `(,org-file . 1)))
+        (with-current-buffer (get-file-buffer org-file)
+          (goto-char (point-max))
+          (insert "
 * id2
 :PROPERTIES:
 :ID: id2
+:END:"))
+        (setq m (org-generic-id-find "ID" "id2" nil t t))
+        (should (equal m nil))
+        (setq m (org-generic-id-find "ID" "id2"))
+        (should (equal m
+                       `(,org-file . 44)))
+
+        (setq m (org-generic-id-find-id-in-file
+                 "SN" "sn1" org-file))
+        (should (equal m
+                       `(,org-file . 1)))
+        (setq m (org-generic-id-find "SN" "sn1"))
+        (should (equal m
+                       `(,org-file . 1)))
+        (with-current-buffer (get-file-buffer org-file)
+          (goto-char (point-max))
+          (insert "
+* sn2
+:PROPERTIES:
 :SN: sn2
 :END:"))
-    (let (m)
-      (setq m (org-generic-id-find-id-in-file
-               "ID" "id1" org-file))
-      (should (equal m
-                     `(,org-file . 1)))
-      (setq m (org-generic-id-find "ID" "id1"))
-      (should (equal m
-                     `(,org-file . 1)))
-      (setq m (org-generic-id-find "ID" "id2" nil t))
-      (should (equal m nil))
-      (setq m (org-generic-id-find "ID" "id2"))
-      (should (equal m
-                     `(,org-file . 45)))
-
-      (setq m (org-generic-id-find-id-in-file
-               "SN" "sn1" org-file))
-      (should (equal m
-                     `(,org-file . 1)))
-      (setq m (org-generic-id-find "SN" "sn1"))
-      (should (equal m
-                     `(,org-file . 1)))
-      (setq m (org-generic-id-find "SN" "sn2" nil t))
-      (should (equal m nil))
-      (setq m (org-generic-id-find "SN" "sn2"))
-      (should (equal m
-                     `(,org-file . 45))))))
+        (setq m (org-generic-id-find "SN" "sn2" nil t t))
+        (should (equal m nil))
+        (setq m (org-generic-id-find "SN" "sn2"))
+        (should (equal m
+                       `(,org-file . 78)))))))


### PR DESCRIPTION
This makes `org-gcal-sync` much faster, since `org-generic-id-update-id-locations` is called many times during updates.