### PR TITLE
Fix org-generic-id--last-update-id-time-put

### DIFF
--- a/org-generic-id.el
+++ b/org-generic-id.el
@@ -502,10 +502,10 @@ This function converts ID-PROP to a symbol in order to query
   ;; Work around the fact that ‘plist-put’ does nothing if the plist is nil,
   ;; since a nil list can’t be mutated in place.
   (if org-generic-id--last-update-id-time
-      (setq org-generic-id--last-update-id-time
-            (list (intern id-prop) time))
-    (plist-put org-generic-id--last-update-id-time
-               (intern id-prop) time)))
+      (plist-put org-generic-id--last-update-id-time
+                 (intern id-prop) time)
+    (setq org-generic-id--last-update-id-time
+          (list (intern id-prop) time))))
 
 (defun org-generic-id--files-find-file-hook ()
   "Update ‘org-generic-id--files’ after a file is loaded."


### PR DESCRIPTION
In https://github.com/kidd/org-gcal.el/pull/203 I reversed the test.