### PR TITLE
Issue 202: Replace switch-to-buffer with set-buffer

### DIFF
--- a/org-generic-id.el
+++ b/org-generic-id.el
@@ -239,7 +239,7 @@ When FILES is given, scan also these files."
                         org-generic-id--files file)))
                   (save-excursion
                     (if buf
-                        (switch-to-buffer buf)
+                        (set-buffer buf)
                       (insert-file-contents file nil nil nil 'replace))
                     (save-restriction
                       (widen)


### PR DESCRIPTION
To quote the emacs source:

	(defun switch-to-buffer (buffer-or-name &optional norecord force-same-window) 
	  "Display buffer BUFFER-OR-NAME in the selected window.

	WARNING: This is NOT the way to work on another buffer temporarily within a Lisp program!  
	Use `set-buffer' instead.  That avoids messing with the window-buffer correspondences.