### PR TITLE
Test branch for wait-timeout-minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,8 +56,8 @@ jobs:
 
     - name: SSH into container on failure
       if: ${{ failure() }}
-      uses: lhotari/action-upterm@v1
-      timeout-minutes: 30
+      uses: telotortium/action-upterm@wait-timeout-minutes
       with:
         ## limits ssh access and adds the ssh public key for the user which triggered the workflow
         limit-access-to-actor: true
+        wait-timeout-minutes: 2


### PR DESCRIPTION
See https://github.com/lhotari/action-upterm/pull/18. We should go back to the upstream branch once the upstream PR is merged.