### PR TITLE
docs(readme): Advise setting epg-pinentry-mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -164,6 +164,12 @@ To do this, follow these steps:
    [these
    instructions](https://gist.github.com/koshatul/2427643668d4e89c0086f297f9ed2130).
 
+Set `epg-pinentry-mode` to `'loopback` to avoid hanging errors during sync (#267).
+
+#+begin_src elisp
+(setq epg-pinentry-mode 'loopback)
+#+end_src
+
 ** Multiple accounts
 
    There's no support for multiple accounts.  If you want to use


### PR DESCRIPTION
**What?**

1. Recommend GPG users set `epg-pinentry-mode` to `'loopback`

**Why?**

Setting this to `loopback` ensures the user is prompted for their password. Without it, the sync request may appear to hang or time out.

Fixes #267 