### PR TITLE
Explicitly require persist.el 0.8

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -4,6 +4,7 @@
 ;; URL: https://github.com/kidd/org-gcal.el
 ;; Version: 0.4.2
 ;; Maintainer: Raimon Grau <raimonster@gmail.com>
+;; Package-Requires: ((persist "0.8"))
 ;; Copyright (C) :2014 myuhe all rights reserved.
 ;; Keywords: convenience,
 


### PR DESCRIPTION
This should resolve a rare data loss bug fixed in this latest version of persist.el. Additionally, by requiring the latest version of persist.el explicitly here, we avoid a bug reported to me via email:

```
Since installing persist v7.0 this morning, I keep getting errors of the following form:

Debugger entered--Lisp error: (wrong-number-of-arguments #<subr persist--defvar-1> 2)

  persist--defvar-1(org-generic-id--last-update-id-time nil)

as org-generic-id.el gets loaded.
```

This bug is caused by stale macro expansions and would be fixed by bumping the required version of persist.el and also bumping the version of org-gcal.el so that users who eagerly run package-upgrade-all will have their org-gcal.el files recompiled.