### PR TITLE
Use multiple calendars from one account

### DIFF
--- a/README.org
+++ b/README.org
@@ -197,6 +197,9 @@ Set `epg-pinentry-mode` to `'loopback` to avoid hanging errors during sync (#267
    3. Select "Settings"
    4. Scroll down to "Integrate calendar" to find the Calendar ID
 
+   Note: Multiple Google accounts (with separate OAuth credentials) are not
+   supported. All calendars must be accessible from your primary account.
+
 ** Different timezone
 
    If you local timezone is different from the Calendar. You can use

--- a/README.org
+++ b/README.org
@@ -170,14 +170,32 @@ Set `epg-pinentry-mode` to `'loopback` to avoid hanging errors during sync (#267
 (setq epg-pinentry-mode 'loopback)
 #+end_src
 
-** Multiple accounts
+** Multiple calendars from one account
 
-   There's no support for multiple accounts.  If you want to use
-   org-gcal with calendars from different accounts, you can give
-   permissions to the account you configured via the calendar's
-   settings interface.
+   You can sync multiple calendars (including shared and subscribed calendars)
+   using a single Google account for authentication. This is useful when you
+   have calendars shared with you or subscribed calendars that are accessible
+   from your primary Google account.
 
-   To get more detailed information you can [[https://digibites.zendesk.com/hc/en-us/articles/200299863-How-do-I-share-my-calendar-with-someone-else-Google-Calendar-or-Outlook-com-][check this link]].
+   Set =org-gcal-primary-account= to your primary Google email address:
+
+   #+begin_src elisp
+   (setq org-gcal-primary-account "your-email@gmail.com"
+         org-gcal-client-id "your-id-foo.apps.googleusercontent.com"
+         org-gcal-client-secret "your-secret"
+         org-gcal-fetch-file-alist '(("your-email@gmail.com" . "~/calendar.org")
+                                     ("shared-calendar-id@group.calendar.google.com" . "~/calendar.org")
+                                     ("subscribed-calendar-id@import.calendar.google.com" . "~/calendar.org")))
+   #+end_src
+
+   When =org-gcal-primary-account= is set, all calendars in =org-gcal-fetch-file-alist=
+   will authenticate using that account, so you only need to authorize once.
+
+   To find the calendar ID for shared or subscribed calendars:
+   1. Go to [[https://calendar.google.com][Google Calendar]]
+   2. Click on the three dots next to the calendar name
+   3. Select "Settings"
+   4. Scroll down to "Integrate calendar" to find the Calendar ID
 
 ** Different timezone
 

--- a/org-gcal.el
+++ b/org-gcal.el
@@ -93,6 +93,17 @@
   :group 'org-gcal
   :type 'string)
 
+(defcustom org-gcal-primary-account nil
+  "Primary Google account for OAuth authentication.
+When set, all calendars in `org-gcal-fetch-file-alist' will authenticate
+using this account instead of their individual calendar IDs.
+This is useful for fetching shared or subscribed calendars that are
+accessible from your primary account.
+Set this to your primary Google email address (e.g., \"user@gmail.com\")."
+  :group 'org-gcal
+  :type '(choice (const :tag "Use calendar ID for auth" nil)
+                 (string :tag "Primary account email")))
+
 (defvaralias 'org-gcal-file-alist 'org-gcal-fetch-file-alist)
 
 (defcustom org-gcal-fetch-file-alist nil
@@ -1373,19 +1384,23 @@ delete calendar info from events on calendars you no longer have access to."
         (deferred:succeed nil)))))
 
 (defun org-gcal--get-access-token (calendar-id)
-  "Return the access token for CALENDAR-ID."
-  (aio-wait-for
-   (oauth2-auto-access-token calendar-id 'org-gcal)))
+  "Return the access token for CALENDAR-ID.
+If `org-gcal-primary-account' is set, use that for authentication instead."
+  (let ((auth-account (or org-gcal-primary-account calendar-id)))
+    (aio-wait-for
+     (oauth2-auto-access-token auth-account 'org-gcal))))
 
 (defun org-gcal--refresh-token (calendar-id)
-  "Refresh OAuth access and return the new access token as a deferred object."
+  "Refresh OAuth access and return the new access token as a deferred object.
+If `org-gcal-primary-account' is set, use that for authentication instead."
   ;; FIXME: For now, we just synchronously wait for the refresh. Once the
   ;; project has been rewritten to use aio
   ;; (https://github.com/kidd/org-gcal.el/issues/191), we can wait for this
   ;; asynchronously as well.
-  (let ((token
-         (aio-wait-for
-          (oauth2-auto-access-token calendar-id 'org-gcal))))
+  (let* ((auth-account (or org-gcal-primary-account calendar-id))
+         (token
+          (aio-wait-for
+           (oauth2-auto-access-token auth-account 'org-gcal))))
     (deferred:succeed token)))
 
 ;;;###autoload


### PR DESCRIPTION
I noticed that when using org-gcal-fetch-file-alist with shared or subscribed calendars (e.g., calendar-id@import.calendar.google.com), org-gcal attempts to authenticate each calendar ID separately. This causes OAuth prompts for accounts the user doesn't control, even though these calendars are already accessible from their primary Google account.

Fix:
Added the org-gcal-primary-account customization variable. When set, all calendars authenticate using the specified account instead of their individual calendar IDs.

Changes
- Added org-gcal-primary-account defcustom
- Modified org-gcal--get-access-token and org-gcal--refresh-token to use primary account when set
- Updated README documentation slightly