### PR TITLE
Save org buffers after fetch and sync

### DIFF
--- a/org-gcal.el
+++ b/org-gcal.el
@@ -454,6 +454,11 @@ CALENDAR-ID-FILE is a cons in ‘org-gcal-fetch-file-alist’, for which see."
      (deferred:nextc it
                      (lambda (entries)
                        (org-gcal--sync-update-entries calendar-id entries skip-export)))
+     (deferred:nextc it
+                     (lambda (_)
+                       (let ((buf (find-buffer-visiting calendar-file)))
+                         (when (and buf (buffer-modified-p buf))
+                           (with-current-buffer buf (save-buffer))))))
      ;; Retrieve the next page of results if needed.
      (deferred:nextc it
                      (lambda (_)
@@ -492,6 +497,11 @@ CALENDAR-ID-FILE is a cons in ‘org-gcal-fetch-file-alist’, for which see."
      (deferred:nextc it
                      (lambda (entries)
                        (org-gcal--sync-update-entries calendar-id entries skip-export)))
+     (deferred:nextc it
+                     (lambda (_)
+                       (let ((buf (find-buffer-visiting calendar-file)))
+                         (when (and buf (buffer-modified-p buf))
+                           (with-current-buffer buf (save-buffer))))))
      ;; Retrieve the next page of results if needed.
      (deferred:nextc it
                      (lambda (_)
@@ -520,7 +530,12 @@ CALENDAR-ID-FILE is a cons in ‘org-gcal-fetch-file-alist’, for which see."
                                                      events nil nil nil nil)))
      (deferred:nextc it
                      (lambda (entries)
-                       (org-gcal--sync-update-entries calendar-id entries skip-export))))))
+                       (org-gcal--sync-update-entries calendar-id entries skip-export)))
+     (deferred:nextc it
+                     (lambda (_)
+                       (let ((buf (find-buffer-visiting calendar-file)))
+                         (when (and buf (buffer-modified-p buf))
+                           (with-current-buffer buf (save-buffer)))))))))
 
 (defun org-gcal--sync-request-events
     (calendar-id page-token up-time down-time)
@@ -728,7 +743,8 @@ Any parent recurring events are appended in-place to the list PARENT-EVENTS."
              (org-entry-put (point) org-gcal-managed-property
                             org-gcal-managed-newly-fetched-mode)))
          nil)))
-     collect it)))
+     collect it)
+    (when (buffer-modified-p) (save-buffer))))
 
 (defun org-gcal--sync-update-entries (calendar-id entries skip-export)
   "Update headlines given by ‘org-gcal--event-entry’ ENTRIES.


### PR DESCRIPTION
Fetched/synced events were only written to buffers, never persisted to disk. Reverting a buffer or restarting Emacs would lose changes.

  1. After each calendar fetch (line ~377) — saves newly inserted events per calendar file
  2. :finally of org-gcal-sync (line ~398) — catches anything modified by sync-buffer phase
  3. :finally of org-gcal-sync-buffer (line ~817) — saves when sync-buffer is called standalone
  
should solve #283